### PR TITLE
Fix libraries in filter.go to reflect how GCE API list filtering works currently

### DIFF
--- a/pkg/cloud/filter/filter.go
+++ b/pkg/cloud/filter/filter.go
@@ -43,17 +43,17 @@ var (
 	None *F
 )
 
-// Regexp returns a filter for fieldName matches regexp v.
+// Regexp returns a filter for fieldName ~ regexp v.
 func Regexp(fieldName, v string) *F {
 	return (&F{}).AndRegexp(fieldName, v)
 }
 
-// NotRegexp returns a filter for fieldName not matches regexp v.
+// NotRegexp returns a filter for fieldName !~ regexp v.
 func NotRegexp(fieldName, v string) *F {
 	return (&F{}).AndNotRegexp(fieldName, v)
 }
 
-// EqualInt returns a filter for fieldName ~ v.
+// EqualInt returns a filter for fieldName = v.
 func EqualInt(fieldName string, v int) *F {
 	return (&F{}).AndEqualInt(fieldName, v)
 }
@@ -63,7 +63,7 @@ func NotEqualInt(fieldName string, v int) *F {
 	return (&F{}).AndNotEqualInt(fieldName, v)
 }
 
-// EqualBool returns a filter for fieldName == v.
+// EqualBool returns a filter for fieldName = v.
 func EqualBool(fieldName string, v bool) *F {
 	return (&F{}).AndEqualBool(fieldName, v)
 }
@@ -104,25 +104,27 @@ type F struct {
 	predicates []filterPredicate
 }
 
+// TODO(rramkumar): Support logical OR
+
 // And joins two filters together.
 func (fl *F) And(rest *F) *F {
 	fl.predicates = append(fl.predicates, rest.predicates...)
 	return fl
 }
 
-// AndRegexp adds a field match string predicate.
+// AndRegexp adds a field ~ string predicate.
 func (fl *F) AndRegexp(fieldName, v string) *F {
-	fl.predicates = append(fl.predicates, filterPredicate{fieldName: fieldName, op: equals, s: &v})
+	fl.predicates = append(fl.predicates, filterPredicate{fieldName: fieldName, op: regexpEquals, s: &v})
 	return fl
 }
 
-// AndNotRegexp adds a field not match string predicate.
+// AndNotRegexp adds a field !~ string predicate.
 func (fl *F) AndNotRegexp(fieldName, v string) *F {
-	fl.predicates = append(fl.predicates, filterPredicate{fieldName: fieldName, op: notEquals, s: &v})
+	fl.predicates = append(fl.predicates, filterPredicate{fieldName: fieldName, op: regexpNotEquals, s: &v})
 	return fl
 }
 
-// AndEqualInt adds a field == int predicate.
+// AndEqualInt adds a field = int predicate.
 func (fl *F) AndEqualInt(fieldName string, v int) *F {
 	fl.predicates = append(fl.predicates, filterPredicate{fieldName: fieldName, op: equals, i: &v})
 	return fl
@@ -134,7 +136,7 @@ func (fl *F) AndNotEqualInt(fieldName string, v int) *F {
 	return fl
 }
 
-// AndEqualBool adds a field == bool predicate.
+// AndEqualBool adds a field = bool predicate.
 func (fl *F) AndEqualBool(fieldName string, v bool) *F {
 	fl.predicates = append(fl.predicates, filterPredicate{fieldName: fieldName, op: equals, b: &v})
 	return fl
@@ -155,7 +157,7 @@ func (fl *F) String() string {
 	for _, p := range fl.predicates {
 		pl = append(pl, "("+p.String()+")")
 	}
-	return strings.Join(pl, " ")
+	return fmt.Sprintf("%q", strings.Join(pl, " "))
 }
 
 // Match returns true if the F as specifies matches the given object. This
@@ -177,8 +179,10 @@ func (fl *F) Match(obj interface{}) bool {
 type filterOp int
 
 const (
-	equals    filterOp = iota
-	notEquals filterOp = iota
+	regexpEquals    filterOp = iota
+	regexpNotEquals filterOp = iota
+	equals          filterOp = iota
+	notEquals       filterOp = iota
 )
 
 // filterPredicate is an individual predicate for a fieldName and value.
@@ -194,10 +198,14 @@ type filterPredicate struct {
 func (fp *filterPredicate) String() string {
 	var op string
 	switch fp.op {
+	case regexpEquals:
+		op = "~"
+	case regexpNotEquals:
+		op = "!~"
 	case equals:
-		op = "eq"
+		op = "="
 	case notEquals:
-		op = "ne"
+		op = "!="
 	default:
 		op = "invalidOp"
 	}
@@ -237,7 +245,10 @@ func (fp *filterPredicate) match(o interface{}) bool {
 			klog.Errorf("Match regexp %q is invalid: %v", *fp.s, err)
 			return false
 		}
-		match = re.Match([]byte(x))
+		match = x == *fp.s
+		if fp.op < regexpNotEquals {
+			match = re.Match([]byte(x))
+		}
 	case int:
 		if fp.i == nil {
 			return false
@@ -251,6 +262,10 @@ func (fp *filterPredicate) match(o interface{}) bool {
 	}
 
 	switch fp.op {
+	case regexpEquals:
+		return match
+	case regexpNotEquals:
+		return !match
 	case equals:
 		return match
 	case notEquals:

--- a/pkg/cloud/filter/filter_test.go
+++ b/pkg/cloud/filter/filter_test.go
@@ -28,15 +28,15 @@ func TestFilterToString(t *testing.T) {
 		f    *F
 		want string
 	}{
-		{Regexp("field1", "abc"), `field1 eq abc`},
-		{NotRegexp("field1", "abc"), `field1 ne abc`},
-		{EqualInt("field1", 13), "field1 eq 13"},
-		{NotEqualInt("field1", 13), "field1 ne 13"},
-		{EqualBool("field1", true), "field1 eq true"},
-		{NotEqualBool("field1", true), "field1 ne true"},
-		{Regexp("field1", "abc").AndRegexp("field2", "def"), `(field1 eq abc) (field2 eq def)`},
-		{Regexp("field1", "abc").AndNotEqualInt("field2", 17), `(field1 eq abc) (field2 ne 17)`},
-		{Regexp("field1", "abc").And(EqualInt("field2", 17)), `(field1 eq abc) (field2 eq 17)`},
+		{Regexp("field1", "abc"), `field1 ~ abc`},
+		{NotRegexp("field1", "abc"), `field1 !~ abc`},
+		{EqualInt("field1", 13), "field1 = 13"},
+		{NotEqualInt("field1", 13), "field1 != 13"},
+		{EqualBool("field1", true), "field1 = true"},
+		{NotEqualBool("field1", true), "field1 != true"},
+		{Regexp("field1", "abc").AndRegexp("field2", "def"), `(field1 ~ abc) (field2 ~ def)`},
+		{Regexp("field1", "abc").AndNotEqualInt("field2", 17), `(field1 ~ abc) (field2 != 17)`},
+		{Regexp("field1", "abc").And(EqualInt("field2", 17)), `(field1 ~ abc) (field2 = 17)`},
 	} {
 		if tc.f.String() != tc.want {
 			t.Errorf("filter %#v String() = %q, want %q", tc.f, tc.f.String(), tc.want)


### PR DESCRIPTION
Biggest changes:

1. Regex is represented by '~' rather than 'eq' 
2. int or bool equality is represented by "=" rather than "=="

Will only submit once I verify this works against GCE. 

/assign @bowei

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-cloud-provider/6)
<!-- Reviewable:end -->
