### PR TITLE
fix Mock for AggregatedList

### DIFF
--- a/pkg/cloud/gen.go
+++ b/pkg/cloud/gen.go
@@ -2385,7 +2385,6 @@ func (m *MockAddresses) AggregatedList(ctx context.Context, fl *filter.F) (map[s
 	objs := map[string][]*ga.Address{}
 	for _, obj := range m.Objects {
 		res, err := ParseResourceURL(obj.ToGA().SelfLink)
-		location := res.Key.Region
 		if err != nil {
 			klog.V(5).Infof("MockAddresses.AggregatedList(%v, %v) = nil, %v", ctx, fl, err)
 			return nil, err
@@ -2393,6 +2392,7 @@ func (m *MockAddresses) AggregatedList(ctx context.Context, fl *filter.F) (map[s
 		if !fl.Match(obj.ToGA()) {
 			continue
 		}
+		location := aggregatedListKey(res.Key)
 		objs[location] = append(objs[location], obj.ToGA())
 	}
 	klog.V(5).Infof("MockAddresses.AggregatedList(%v, %v) = [%v items], nil", ctx, fl, len(objs))
@@ -2805,7 +2805,6 @@ func (m *MockAlphaAddresses) AggregatedList(ctx context.Context, fl *filter.F) (
 	objs := map[string][]*alpha.Address{}
 	for _, obj := range m.Objects {
 		res, err := ParseResourceURL(obj.ToAlpha().SelfLink)
-		location := res.Key.Region
 		if err != nil {
 			klog.V(5).Infof("MockAlphaAddresses.AggregatedList(%v, %v) = nil, %v", ctx, fl, err)
 			return nil, err
@@ -2813,6 +2812,7 @@ func (m *MockAlphaAddresses) AggregatedList(ctx context.Context, fl *filter.F) (
 		if !fl.Match(obj.ToAlpha()) {
 			continue
 		}
+		location := aggregatedListKey(res.Key)
 		objs[location] = append(objs[location], obj.ToAlpha())
 	}
 	klog.V(5).Infof("MockAlphaAddresses.AggregatedList(%v, %v) = [%v items], nil", ctx, fl, len(objs))
@@ -3225,7 +3225,6 @@ func (m *MockBetaAddresses) AggregatedList(ctx context.Context, fl *filter.F) (m
 	objs := map[string][]*beta.Address{}
 	for _, obj := range m.Objects {
 		res, err := ParseResourceURL(obj.ToBeta().SelfLink)
-		location := res.Key.Region
 		if err != nil {
 			klog.V(5).Infof("MockBetaAddresses.AggregatedList(%v, %v) = nil, %v", ctx, fl, err)
 			return nil, err
@@ -3233,6 +3232,7 @@ func (m *MockBetaAddresses) AggregatedList(ctx context.Context, fl *filter.F) (m
 		if !fl.Match(obj.ToBeta()) {
 			continue
 		}
+		location := aggregatedListKey(res.Key)
 		objs[location] = append(objs[location], obj.ToBeta())
 	}
 	klog.V(5).Infof("MockBetaAddresses.AggregatedList(%v, %v) = [%v items], nil", ctx, fl, len(objs))
@@ -15725,7 +15725,6 @@ func (m *MockAlphaNetworkEndpointGroups) AggregatedList(ctx context.Context, fl 
 	objs := map[string][]*alpha.NetworkEndpointGroup{}
 	for _, obj := range m.Objects {
 		res, err := ParseResourceURL(obj.ToAlpha().SelfLink)
-		location := res.Key.Zone
 		if err != nil {
 			klog.V(5).Infof("MockAlphaNetworkEndpointGroups.AggregatedList(%v, %v) = nil, %v", ctx, fl, err)
 			return nil, err
@@ -15733,6 +15732,7 @@ func (m *MockAlphaNetworkEndpointGroups) AggregatedList(ctx context.Context, fl 
 		if !fl.Match(obj.ToAlpha()) {
 			continue
 		}
+		location := aggregatedListKey(res.Key)
 		objs[location] = append(objs[location], obj.ToAlpha())
 	}
 	klog.V(5).Infof("MockAlphaNetworkEndpointGroups.AggregatedList(%v, %v) = [%v items], nil", ctx, fl, len(objs))
@@ -16285,7 +16285,6 @@ func (m *MockBetaNetworkEndpointGroups) AggregatedList(ctx context.Context, fl *
 	objs := map[string][]*beta.NetworkEndpointGroup{}
 	for _, obj := range m.Objects {
 		res, err := ParseResourceURL(obj.ToBeta().SelfLink)
-		location := res.Key.Zone
 		if err != nil {
 			klog.V(5).Infof("MockBetaNetworkEndpointGroups.AggregatedList(%v, %v) = nil, %v", ctx, fl, err)
 			return nil, err
@@ -16293,6 +16292,7 @@ func (m *MockBetaNetworkEndpointGroups) AggregatedList(ctx context.Context, fl *
 		if !fl.Match(obj.ToBeta()) {
 			continue
 		}
+		location := aggregatedListKey(res.Key)
 		objs[location] = append(objs[location], obj.ToBeta())
 	}
 	klog.V(5).Infof("MockBetaNetworkEndpointGroups.AggregatedList(%v, %v) = [%v items], nil", ctx, fl, len(objs))
@@ -16845,7 +16845,6 @@ func (m *MockNetworkEndpointGroups) AggregatedList(ctx context.Context, fl *filt
 	objs := map[string][]*ga.NetworkEndpointGroup{}
 	for _, obj := range m.Objects {
 		res, err := ParseResourceURL(obj.ToGA().SelfLink)
-		location := res.Key.Zone
 		if err != nil {
 			klog.V(5).Infof("MockNetworkEndpointGroups.AggregatedList(%v, %v) = nil, %v", ctx, fl, err)
 			return nil, err
@@ -16853,6 +16852,7 @@ func (m *MockNetworkEndpointGroups) AggregatedList(ctx context.Context, fl *filt
 		if !fl.Match(obj.ToGA()) {
 			continue
 		}
+		location := aggregatedListKey(res.Key)
 		objs[location] = append(objs[location], obj.ToGA())
 	}
 	klog.V(5).Infof("MockNetworkEndpointGroups.AggregatedList(%v, %v) = [%v items], nil", ctx, fl, len(objs))

--- a/pkg/cloud/gen/main.go
+++ b/pkg/cloud/gen/main.go
@@ -603,12 +603,6 @@ func (m *{{.MockWrapType}}) AggregatedList(ctx context.Context, fl *filter.F) (m
 	objs := map[string][]*{{.FQObjectType}}{}
 	for _, obj := range m.Objects {
 		res, err := ParseResourceURL(obj.To{{.VersionTitle}}().SelfLink)
-		{{- if .KeyIsRegional}}
-		location := res.Key.Region
-		{{- end -}}
-		{{- if .KeyIsZonal}}
-		location := res.Key.Zone
-		{{- end}}
 		if err != nil {
 			klog.V(5).Infof("{{.MockWrapType}}.AggregatedList(%v, %v) = nil, %v", ctx, fl, err)
 			return nil, err
@@ -616,6 +610,7 @@ func (m *{{.MockWrapType}}) AggregatedList(ctx context.Context, fl *filter.F) (m
 		if !fl.Match(obj.To{{.VersionTitle}}()) {
 			continue
 		}
+        location := aggregatedListKey(res.Key)
 		objs[location] = append(objs[location], obj.To{{.VersionTitle}}())
 	}
 	klog.V(5).Infof("{{.MockWrapType}}.AggregatedList(%v, %v) = [%v items], nil", ctx, fl, len(objs))

--- a/pkg/cloud/utils.go
+++ b/pkg/cloud/utils.go
@@ -199,3 +199,17 @@ func SelfLink(ver meta.Version, project, resource string, key *meta.Key) string 
 	return fmt.Sprintf("%s/%s", prefix, RelativeResourceName(project, resource, key))
 
 }
+
+// aggregatedListKey return the aggregated list key based on the resource key.
+func aggregatedListKey(k *meta.Key) string {
+	switch k.Type() {
+	case meta.Regional:
+		return fmt.Sprintf("regions/%s", k.Region)
+	case meta.Zonal:
+		return fmt.Sprintf("zones/%s", k.Zone)
+	case meta.Global:
+		return "global"
+	default:
+		return "unknownScope"
+	}
+}

--- a/pkg/cloud/utils_test.go
+++ b/pkg/cloud/utils_test.go
@@ -289,3 +289,27 @@ func TestSelfLink(t *testing.T) {
 		}
 	}
 }
+
+func TestAggregatedListKey(t *testing.T) {
+	for _, tc := range []struct {
+		key          *meta.Key
+		expectOutput string
+	}{
+		{
+			key:          meta.ZonalKey("a", "zone1"),
+			expectOutput: "zones/zone1",
+		},
+		{
+			key:          meta.RegionalKey("a", "region1"),
+			expectOutput: "regions/region1",
+		},
+		{
+			key:          meta.GlobalKey("a"),
+			expectOutput: "global",
+		},
+	} {
+		if tc.expectOutput != aggregatedListKey(tc.key) {
+			t.Errorf("expect output %q, but got %q", tc.expectOutput, aggregatedListKey(tc.key))
+		}
+	}
+}


### PR DESCRIPTION
The current mock for AggregatedList mock return the zone/region name as key directly. The real GCE API return key in following format `zones/{zone}`, `regions/{region}` or `global`