### PR TITLE
Fix libraries in filter.go to use the correct operators supported by GCE

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -220,6 +220,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "golang.org/x/oauth2/google",
     "google.golang.org/api/compute/v0.alpha",
     "google.golang.org/api/compute/v0.beta",
     "google.golang.org/api/compute/v1",

--- a/pkg/cloud/filter/filter.go
+++ b/pkg/cloud/filter/filter.go
@@ -43,32 +43,32 @@ var (
 	None *F
 )
 
-// Regexp returns a filter for fieldName ~ regexp v.
+// Regexp returns a filter for fieldName eq regexp v.
 func Regexp(fieldName, v string) *F {
 	return (&F{}).AndRegexp(fieldName, v)
 }
 
-// NotRegexp returns a filter for fieldName !~ regexp v.
+// NotRegexp returns a filter for fieldName ne regexp v.
 func NotRegexp(fieldName, v string) *F {
 	return (&F{}).AndNotRegexp(fieldName, v)
 }
 
-// EqualInt returns a filter for fieldName = v.
+// EqualInt returns a filter for fieldName eq v.
 func EqualInt(fieldName string, v int) *F {
 	return (&F{}).AndEqualInt(fieldName, v)
 }
 
-// NotEqualInt returns a filter for fieldName != v.
+// NotEqualInt returns a filter for fieldName ne v.
 func NotEqualInt(fieldName string, v int) *F {
 	return (&F{}).AndNotEqualInt(fieldName, v)
 }
 
-// EqualBool returns a filter for fieldName = v.
+// EqualBool returns a filter for fieldName eq v.
 func EqualBool(fieldName string, v bool) *F {
 	return (&F{}).AndEqualBool(fieldName, v)
 }
 
-// NotEqualBool returns a filter for fieldName != v.
+// NotEqualBool returns a filter for fieldName ne v.
 func NotEqualBool(fieldName string, v bool) *F {
 	return (&F{}).AndNotEqualBool(fieldName, v)
 }
@@ -199,13 +199,16 @@ func (fp *filterPredicate) String() string {
 	var op string
 	switch fp.op {
 	case regexpEquals:
-		op = "~"
+		// GCE API maps regexp comparison to 'eq'
+		op = "eq"
 	case regexpNotEquals:
-		op = "!~"
+		op = "ne"
+	// Since GCE API does not allow using a mix of 'eq' and '=' operators,
+	// we use 'eq' everywhere
 	case equals:
-		op = "="
+		op = "eq"
 	case notEquals:
-		op = "!="
+		op = "ne"
 	default:
 		op = "invalidOp"
 	}

--- a/pkg/cloud/filter/filter_resource_test.go
+++ b/pkg/cloud/filter/filter_resource_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+)
+
+var (
+	projectID = os.Getenv("PROJECT_ID")
+	// test requires e2e cluster to be present in the project specified in order to match these filters
+	routeFilters   = map[string]interface{}{"name": "e2e-test-.*", "description": "k8s-node-route", "priority": 1000}
+	networkFilters = map[string]interface{}{"autoCreateSubnetworks": false}
+)
+
+func TestFilterResources(t *testing.T) {
+	t.Parallel()
+	if projectID == "" {
+		t.Skip("Missing projectID... skipping test")
+	}
+
+	// See https://cloud.google.com/docs/authentication/.
+	// Use GOOGLE_APPLICATION_CREDENTIALS environment variable to specify
+	// a service account key file to authenticate to the API.
+	hc, err := google.DefaultClient(context.Background(), compute.ComputeScope)
+	if err != nil {
+		t.Errorf("Could not get authenticated client: %v", err)
+	}
+
+	svc, err := compute.New(hc)
+	if err != nil {
+		t.Errorf("Could not initialize compute client: %v", err)
+	}
+
+	if err := listRoutes(svc, projectID, t); err != nil {
+		t.Errorf("Failed to rist routes - %v", err)
+	}
+	if err = listNetworks(svc, projectID, t); err != nil {
+		t.Errorf("Failed to rist routes - %v", err)
+	}
+}
+
+func constructFilter(params map[string]interface{}) string {
+	var fl *F
+	for key, val := range params {
+		switch val.(type) {
+		case string:
+			if fl == nil {
+				fl = Regexp(key, val.(string))
+			} else {
+				fl.AndRegexp(key, val.(string))
+			}
+		case bool:
+			if fl == nil {
+				fl = EqualBool(key, val.(bool))
+			} else {
+				fl.AndEqualBool(key, val.(bool))
+			}
+		case int:
+			if fl == nil {
+				fl = EqualInt(key, val.(int))
+			} else {
+				fl.AndEqualInt(key, val.(int))
+			}
+		}
+	}
+	if fl == nil {
+		return ""
+	}
+	return fl.String()
+}
+
+func listRoutes(svc *compute.Service, projectID string, t *testing.T) error {
+	fstr := constructFilter(routeFilters)
+	list, err := svc.Routes.List(projectID).Filter(fstr).Do()
+	if err != nil {
+		return fmt.Errorf("failed to list routes: %v", err)
+	}
+	t.Logf("Got %d matching routes matching filter '%s':", len(list.Items), fstr)
+	for ix, v := range list.Items {
+		t.Logf("%d. %s", ix, v.Name)
+	}
+	return nil
+}
+
+func listNetworks(svc *compute.Service, projectID string, t *testing.T) error {
+	fstr := constructFilter(networkFilters)
+	list, err := svc.Networks.List(projectID).Filter(fstr).Do()
+	if err != nil {
+		return fmt.Errorf("failed to list networks: %v", err)
+	}
+	t.Logf("Got %d matching networks matching filter '%s':", len(list.Items), fstr)
+	for ix, v := range list.Items {
+		t.Logf("%d. %s", ix, v.Name)
+	}
+	return nil
+}

--- a/pkg/cloud/filter/filter_test.go
+++ b/pkg/cloud/filter/filter_test.go
@@ -28,15 +28,15 @@ func TestFilterToString(t *testing.T) {
 		f    *F
 		want string
 	}{
-		{Regexp("field1", "abc"), `field1 ~ abc`},
-		{NotRegexp("field1", "abc"), `field1 !~ abc`},
-		{EqualInt("field1", 13), "field1 = 13"},
-		{NotEqualInt("field1", 13), "field1 != 13"},
-		{EqualBool("field1", true), "field1 = true"},
-		{NotEqualBool("field1", true), "field1 != true"},
-		{Regexp("field1", "abc").AndRegexp("field2", "def"), `(field1 ~ abc) (field2 ~ def)`},
-		{Regexp("field1", "abc").AndNotEqualInt("field2", 17), `(field1 ~ abc) (field2 != 17)`},
-		{Regexp("field1", "abc").And(EqualInt("field2", 17)), `(field1 ~ abc) (field2 = 17)`},
+		{Regexp("field1", "abc"), `field1 eq abc`},
+		{NotRegexp("field1", "abc"), `field1 ne abc`},
+		{EqualInt("field1", 13), "field1 eq 13"},
+		{NotEqualInt("field1", 13), "field1 ne 13"},
+		{EqualBool("field1", true), "field1 eq true"},
+		{NotEqualBool("field1", true), "field1 ne true"},
+		{Regexp("field1", "abc").AndRegexp("field2", "def"), `(field1 eq abc) (field2 eq def)`},
+		{Regexp("field1", "abc").AndNotEqualInt("field2", 17), `(field1 eq abc) (field2 ne 17)`},
+		{Regexp("field1", "abc").And(EqualInt("field2", 17)), `(field1 eq abc) (field2 eq 17)`},
 	} {
 		if tc.f.String() != tc.want {
 			t.Errorf("filter %#v String() = %q, want %q", tc.f, tc.f.String(), tc.want)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/k8s-cloud-provider#6

Most GCE APIs don't support regexp filter, hence reverting this.

Picked this up in k/k and Routes Controller started failing when listing routes with:

GCERoutes.List(context.Background.WithDeadline(2019-08-19 23:56:59.880823189 +0000 UTC m=+5923.032348891 [59m59.8650081s]), ..., (name ~ e2e-test-.*) (network ~ https://www.googleapis.com/compute/v1/projects/pavithrar-k8s-dev/global/networks/e2e-test) (description ~ k8s-node-route)) = <nil>, googleapi: Error 400: Invalid value for field 'filter': '(name ~ e2e-test-pavithrar-.*) (network ~ https://www.googleapis.com/compute/v1/projects/pavithrar-k8s-dev/global/networks/e2e-test-pavithrar) (description ~ k8s-node-route)'. Invalid list filter expression., invalid

The GCE APIs only support filter of the form "name = value" and not regexp. gcloud seems to be implementing regex filter and invoking API to get the full list.
ingress-gce uses composite types for most resources and no filter so far, which is probably why it has not broken any ingress tests.