### PR TITLE
During polling, return error on error instead of continued polling

### DIFF
--- a/pkg/cloud/service.go
+++ b/pkg/cloud/service.go
@@ -86,7 +86,7 @@ func (s *Service) pollOperation(ctx context.Context, op operation) error {
 		// returning ctx.Err().
 		select {
 		case <-ctx.Done():
-			klog.V(5).Infof("op.pollOperation(%v, %v) not completed, poll count = %d, ctx.Err = %v", ctx, op, pollCount, ctx.Err())
+      klog.V(5).Infof("op.pollOperation(%v, %v) not completed, poll count = %d, ctx.Err = %v", ctx, op, pollCount, ctx.Err())
 			return ctx.Err()
 		default:
 			// ctx is not canceled, continue immediately
@@ -95,16 +95,13 @@ func (s *Service) pollOperation(ctx context.Context, op operation) error {
 		pollCount++
 		klog.V(5).Infof("op.isDone(%v) waiting; op = %v, poll count = %d", ctx, op, pollCount)
 		s.RateLimiter.Accept(ctx, op.rateLimitKey())
-		done, err := op.isDone(ctx)
-		if err != nil {
+		switch done, err := op.isDone(ctx); {
+		case err != nil:
 			klog.V(5).Infof("op.isDone(%v) error; op = %v, poll count = %d, err = %v, retrying", ctx, op, pollCount, err)
-		}
-
-		if done {
-			break
+			return err
+		case done:
+                        klog.V(5).Infof("op.isDone(%v) complete; op = %v, poll count = %d, op.err = %v", ctx, op, pollCount, op.error())
+			return op.error()
 		}
 	}
-
-	klog.V(5).Infof("op.isDone(%v) complete; op = %v, poll count = %d, op.err = %v", ctx, op, pollCount, op.error())
-	return op.error()
 }


### PR DESCRIPTION
Return error on error instead of continuing polling (and likely running into the same error)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-cloud-provider/25)
<!-- Reviewable:end -->
