### PR TITLE
Fix typo in pkg/cloud/service_test.go

### DIFF
--- a/pkg/cloud/service_test.go
+++ b/pkg/cloud/service_test.go
@@ -18,30 +18,6 @@ package cloud
 
 import (
 	"context"
-	"fmt"
-	"testing"
-)
-
-/*
-Copyright 2018 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-package cloud
-
-import (
-	"context"
 	"errors"
 	"testing"
 	"time"


### PR DESCRIPTION
The copyright header and package name were duplicated. Introduced by #25

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-cloud-provider/26)
<!-- Reviewable:end -->
