### PR TITLE
Test parsing resourceURL with a different basepath

### DIFF
--- a/pkg/cloud/utils_test.go
+++ b/pkg/cloud/utils_test.go
@@ -150,6 +150,11 @@ func TestParseResourceURL(t *testing.T) {
 			"zones/us-central1-c/instances/instance-1",
 			&ResourceID{"", "instances", meta.ZonalKey("instance-1", "us-central1-c")},
 		},
+		{
+			"https://compute.googleapis.com/compute/v1/projects/some-gce-project/regions/us-central1/backendServices/bs1",
+			&ResourceID{"some-gce-project", "backendServices", meta.RegionalKey("bs1", "us-central1")},
+		},
+		
 	} {
 		r, err := ParseResourceURL(tc.in)
 		if err != nil {


### PR DESCRIPTION
BasePath changed to compute.googleapis.com in gce client version[ 0.10.0 ](https://raw.githubusercontent.com/googleapis/google-api-go-client/09a9d0a772eb18da65a7917760cf4ca9ae943c83/compute/v1/compute-gen.go)and later.

Adding a test to make sure ResourceURL parsing works.