### PR TITLE
Add support for ListUsable() methods

### DIFF
--- a/pkg/cloud/meta/meta.go
+++ b/pkg/cloud/meta/meta.go
@@ -42,6 +42,8 @@ const (
 	CustomOps = 1 << iota
 	// AggregatedList will generated a method for AggregatedList().
 	AggregatedList = 1 << iota
+	// ListUsable will generate a method for ListUsable().
+	ListUsable = 1 << iota
 
 	// ReadOnly specifies that the given resource is read-only and should not
 	// have insert() or delete() methods generated for the wrapper.

--- a/pkg/cloud/meta/service.go
+++ b/pkg/cloud/meta/service.go
@@ -99,6 +99,16 @@ func (i *ServiceInfo) ObjectAggregatedListType() string {
 	return fmt.Sprintf("%v.%vAggregatedList", i.Version(), i.Object)
 }
 
+// ObjectListUsableType is the compute List type for the object (contains Items field).
+func (i *ServiceInfo) ObjectListUsableType() string {
+	return fmt.Sprintf("%v.Usable%vAggregatedList", i.version, i.Service)
+}
+
+// FQObjectType is fully qualified name of the object (e.g. compute.Instance).
+func (i *ServiceInfo) FQListUsableObjectType() string {
+	return fmt.Sprintf("%v.Usable%v", i.Version(), i.Object)
+}
+
 // MockWrapType is the name of the concrete mock for this type.
 func (i *ServiceInfo) MockWrapType() string {
 	return "Mock" + i.WrapType()
@@ -219,6 +229,10 @@ func (i *ServiceInfo) AggregatedListField() string {
 		return i.Service
 	}
 	return i.aggregatedListField
+}
+
+func (i *ServiceInfo) ListUsable() bool {
+	return i.options&ListUsable != 0
 }
 
 // ServiceGroup is a grouping of the same service but at different API versions.


### PR DESCRIPTION
In classic fashion, this is kind of hassle because the GCE API returns a different type called `UsableX` (where x is the resource).

Tested on Subnetworks, which is the only object that has a ListUsable method in the API.