### PR TITLE
Cover nil for ResourceID Equal()

### DIFF
--- a/pkg/cloud/utils.go
+++ b/pkg/cloud/utils.go
@@ -39,16 +39,20 @@ type ResourceID struct {
 
 // Equal returns true if two resource IDs are equal.
 func (r *ResourceID) Equal(other *ResourceID) bool {
-	if r.ProjectID != other.ProjectID || r.Resource != other.Resource {
-		return false
+	switch {
+	case r == nil && other == nil:
+	  return true
+	case r == nil || other == nil:
+	  return false
+	case r.ProjectID != other.ProjectID || r.Resource != other.Resource:
+	  return false
+	case r.Key != nil && other.Key != nil:
+	  return *r.Key == *other.Key
+	case r.Key == nil && other.Key == nil:
+	  return true
+	default:
+	  return false
 	}
-	if r.Key != nil && other.Key != nil {
-		return *r.Key == *other.Key
-	}
-	if r.Key == nil && other.Key == nil {
-		return true
-	}
-	return false
 }
 
 // RelativeResourceName returns the relative resource name string

--- a/pkg/cloud/utils_test.go
+++ b/pkg/cloud/utils_test.go
@@ -42,6 +42,11 @@ func TestEqualResourceID(t *testing.T) {
 			a: &ResourceID{"some-gce-project", "projects", meta.GlobalKey("us-central1")},
 			b: &ResourceID{"some-gce-project", "projects", meta.GlobalKey("us-central1")},
 		},
+		{
+			a: nil,
+			b: nil,
+		},
+
 	} {
 		if !tc.a.Equal(tc.b) {
 			t.Errorf("%v.Equal(%v) = false, want true", tc.a, tc.b)
@@ -63,6 +68,10 @@ func TestEqualResourceID(t *testing.T) {
 		{
 			a: &ResourceID{"some-gce-project", "networks", meta.GlobalKey("us-central1")},
 			b: &ResourceID{"some-gce-project", "projects", meta.GlobalKey("us-central1")},
+		},
+		{
+			a: &ResourceID{"some-gce-project", "projects", meta.GlobalKey("us-central1")},
+			b: nil,
 		},
 	} {
 		if tc.a.Equal(tc.b) {


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/pull/102913#issuecomment-864175076

> panic: runtime error: invalid memory address or nil pointer dereference [recovered]
> 	panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x37d725a]
> 
> A failure in legacy-cloud-providers/gce :/
> This directory is blocked for commits.
> 
> Looks like we need a nil pointer check here and return false if "other" is nil: