### PR TITLE
Add SetLabels() Methods to ForwardingRules

### DIFF
--- a/pkg/cloud/gen.go
+++ b/pkg/cloud/gen.go
@@ -11887,6 +11887,7 @@ type ForwardingRules interface {
 	List(ctx context.Context, region string, fl *filter.F) ([]*ga.ForwardingRule, error)
 	Insert(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule) error
 	Delete(ctx context.Context, key *meta.Key) error
+	SetLabels(context.Context, *meta.Key, *ga.RegionSetLabelsRequest) error
 	SetTarget(context.Context, *meta.Key, *ga.TargetReference) error
 }
 
@@ -11927,6 +11928,7 @@ type MockForwardingRules struct {
 	ListHook      func(ctx context.Context, region string, fl *filter.F, m *MockForwardingRules) (bool, []*ga.ForwardingRule, error)
 	InsertHook    func(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule, m *MockForwardingRules) (bool, error)
 	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockForwardingRules) (bool, error)
+	SetLabelsHook func(context.Context, *meta.Key, *ga.RegionSetLabelsRequest, *MockForwardingRules) error
 	SetTargetHook func(context.Context, *meta.Key, *ga.TargetReference, *MockForwardingRules) error
 
 	// X is extra state that can be used as part of the mock. Generated code
@@ -12074,6 +12076,14 @@ func (m *MockForwardingRules) Delete(ctx context.Context, key *meta.Key) error {
 // Obj wraps the object for use in the mock.
 func (m *MockForwardingRules) Obj(o *ga.ForwardingRule) *MockForwardingRulesObj {
 	return &MockForwardingRulesObj{o}
+}
+
+// SetLabels is a mock for the corresponding method.
+func (m *MockForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *ga.RegionSetLabelsRequest) error {
+	if m.SetLabelsHook != nil {
+		return m.SetLabelsHook(ctx, key, arg0, m)
+	}
+	return nil
 }
 
 // SetTarget is a mock for the corresponding method.
@@ -12225,6 +12235,39 @@ func (g *GCEForwardingRules) Delete(ctx context.Context, key *meta.Key) error {
 	return err
 }
 
+// SetLabels is a method on GCEForwardingRules.
+func (g *GCEForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *ga.RegionSetLabelsRequest) error {
+	klog.V(5).Infof("GCEForwardingRules.SetLabels(%v, %v, ...): called", ctx, key)
+
+	if !key.Valid() {
+		klog.V(2).Infof("GCEForwardingRules.SetLabels(%v, %v, ...): key is invalid (%#v)", ctx, key, key)
+		return fmt.Errorf("invalid GCE key (%+v)", key)
+	}
+	projectID := g.s.ProjectRouter.ProjectID(ctx, "ga", "ForwardingRules")
+	rk := &RateLimitKey{
+		ProjectID: projectID,
+		Operation: "SetLabels",
+		Version:   meta.Version("ga"),
+		Service:   "ForwardingRules",
+	}
+	klog.V(5).Infof("GCEForwardingRules.SetLabels(%v, %v, ...): projectID = %v, rk = %+v", ctx, key, projectID, rk)
+
+	if err := g.s.RateLimiter.Accept(ctx, rk); err != nil {
+		klog.V(4).Infof("GCEForwardingRules.SetLabels(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
+		return err
+	}
+	call := g.s.GA.ForwardingRules.SetLabels(projectID, key.Region, key.Name, arg0)
+	call.Context(ctx)
+	op, err := call.Do()
+	if err != nil {
+		klog.V(4).Infof("GCEForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+		return err
+	}
+	err = g.s.WaitForCompletion(ctx, op)
+	klog.V(4).Infof("GCEForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+	return err
+}
+
 // SetTarget is a method on GCEForwardingRules.
 func (g *GCEForwardingRules) SetTarget(ctx context.Context, key *meta.Key, arg0 *ga.TargetReference) error {
 	klog.V(5).Infof("GCEForwardingRules.SetTarget(%v, %v, ...): called", ctx, key)
@@ -12264,6 +12307,7 @@ type AlphaForwardingRules interface {
 	List(ctx context.Context, region string, fl *filter.F) ([]*alpha.ForwardingRule, error)
 	Insert(ctx context.Context, key *meta.Key, obj *alpha.ForwardingRule) error
 	Delete(ctx context.Context, key *meta.Key) error
+	SetLabels(context.Context, *meta.Key, *alpha.RegionSetLabelsRequest) error
 	SetTarget(context.Context, *meta.Key, *alpha.TargetReference) error
 }
 
@@ -12304,6 +12348,7 @@ type MockAlphaForwardingRules struct {
 	ListHook      func(ctx context.Context, region string, fl *filter.F, m *MockAlphaForwardingRules) (bool, []*alpha.ForwardingRule, error)
 	InsertHook    func(ctx context.Context, key *meta.Key, obj *alpha.ForwardingRule, m *MockAlphaForwardingRules) (bool, error)
 	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockAlphaForwardingRules) (bool, error)
+	SetLabelsHook func(context.Context, *meta.Key, *alpha.RegionSetLabelsRequest, *MockAlphaForwardingRules) error
 	SetTargetHook func(context.Context, *meta.Key, *alpha.TargetReference, *MockAlphaForwardingRules) error
 
 	// X is extra state that can be used as part of the mock. Generated code
@@ -12451,6 +12496,14 @@ func (m *MockAlphaForwardingRules) Delete(ctx context.Context, key *meta.Key) er
 // Obj wraps the object for use in the mock.
 func (m *MockAlphaForwardingRules) Obj(o *alpha.ForwardingRule) *MockForwardingRulesObj {
 	return &MockForwardingRulesObj{o}
+}
+
+// SetLabels is a mock for the corresponding method.
+func (m *MockAlphaForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *alpha.RegionSetLabelsRequest) error {
+	if m.SetLabelsHook != nil {
+		return m.SetLabelsHook(ctx, key, arg0, m)
+	}
+	return nil
 }
 
 // SetTarget is a mock for the corresponding method.
@@ -12602,6 +12655,39 @@ func (g *GCEAlphaForwardingRules) Delete(ctx context.Context, key *meta.Key) err
 	return err
 }
 
+// SetLabels is a method on GCEAlphaForwardingRules.
+func (g *GCEAlphaForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *alpha.RegionSetLabelsRequest) error {
+	klog.V(5).Infof("GCEAlphaForwardingRules.SetLabels(%v, %v, ...): called", ctx, key)
+
+	if !key.Valid() {
+		klog.V(2).Infof("GCEAlphaForwardingRules.SetLabels(%v, %v, ...): key is invalid (%#v)", ctx, key, key)
+		return fmt.Errorf("invalid GCE key (%+v)", key)
+	}
+	projectID := g.s.ProjectRouter.ProjectID(ctx, "alpha", "ForwardingRules")
+	rk := &RateLimitKey{
+		ProjectID: projectID,
+		Operation: "SetLabels",
+		Version:   meta.Version("alpha"),
+		Service:   "ForwardingRules",
+	}
+	klog.V(5).Infof("GCEAlphaForwardingRules.SetLabels(%v, %v, ...): projectID = %v, rk = %+v", ctx, key, projectID, rk)
+
+	if err := g.s.RateLimiter.Accept(ctx, rk); err != nil {
+		klog.V(4).Infof("GCEAlphaForwardingRules.SetLabels(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
+		return err
+	}
+	call := g.s.Alpha.ForwardingRules.SetLabels(projectID, key.Region, key.Name, arg0)
+	call.Context(ctx)
+	op, err := call.Do()
+	if err != nil {
+		klog.V(4).Infof("GCEAlphaForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+		return err
+	}
+	err = g.s.WaitForCompletion(ctx, op)
+	klog.V(4).Infof("GCEAlphaForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+	return err
+}
+
 // SetTarget is a method on GCEAlphaForwardingRules.
 func (g *GCEAlphaForwardingRules) SetTarget(ctx context.Context, key *meta.Key, arg0 *alpha.TargetReference) error {
 	klog.V(5).Infof("GCEAlphaForwardingRules.SetTarget(%v, %v, ...): called", ctx, key)
@@ -12641,6 +12727,7 @@ type BetaForwardingRules interface {
 	List(ctx context.Context, region string, fl *filter.F) ([]*beta.ForwardingRule, error)
 	Insert(ctx context.Context, key *meta.Key, obj *beta.ForwardingRule) error
 	Delete(ctx context.Context, key *meta.Key) error
+	SetLabels(context.Context, *meta.Key, *beta.RegionSetLabelsRequest) error
 	SetTarget(context.Context, *meta.Key, *beta.TargetReference) error
 }
 
@@ -12681,6 +12768,7 @@ type MockBetaForwardingRules struct {
 	ListHook      func(ctx context.Context, region string, fl *filter.F, m *MockBetaForwardingRules) (bool, []*beta.ForwardingRule, error)
 	InsertHook    func(ctx context.Context, key *meta.Key, obj *beta.ForwardingRule, m *MockBetaForwardingRules) (bool, error)
 	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockBetaForwardingRules) (bool, error)
+	SetLabelsHook func(context.Context, *meta.Key, *beta.RegionSetLabelsRequest, *MockBetaForwardingRules) error
 	SetTargetHook func(context.Context, *meta.Key, *beta.TargetReference, *MockBetaForwardingRules) error
 
 	// X is extra state that can be used as part of the mock. Generated code
@@ -12828,6 +12916,14 @@ func (m *MockBetaForwardingRules) Delete(ctx context.Context, key *meta.Key) err
 // Obj wraps the object for use in the mock.
 func (m *MockBetaForwardingRules) Obj(o *beta.ForwardingRule) *MockForwardingRulesObj {
 	return &MockForwardingRulesObj{o}
+}
+
+// SetLabels is a mock for the corresponding method.
+func (m *MockBetaForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *beta.RegionSetLabelsRequest) error {
+	if m.SetLabelsHook != nil {
+		return m.SetLabelsHook(ctx, key, arg0, m)
+	}
+	return nil
 }
 
 // SetTarget is a mock for the corresponding method.
@@ -12979,6 +13075,39 @@ func (g *GCEBetaForwardingRules) Delete(ctx context.Context, key *meta.Key) erro
 	return err
 }
 
+// SetLabels is a method on GCEBetaForwardingRules.
+func (g *GCEBetaForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *beta.RegionSetLabelsRequest) error {
+	klog.V(5).Infof("GCEBetaForwardingRules.SetLabels(%v, %v, ...): called", ctx, key)
+
+	if !key.Valid() {
+		klog.V(2).Infof("GCEBetaForwardingRules.SetLabels(%v, %v, ...): key is invalid (%#v)", ctx, key, key)
+		return fmt.Errorf("invalid GCE key (%+v)", key)
+	}
+	projectID := g.s.ProjectRouter.ProjectID(ctx, "beta", "ForwardingRules")
+	rk := &RateLimitKey{
+		ProjectID: projectID,
+		Operation: "SetLabels",
+		Version:   meta.Version("beta"),
+		Service:   "ForwardingRules",
+	}
+	klog.V(5).Infof("GCEBetaForwardingRules.SetLabels(%v, %v, ...): projectID = %v, rk = %+v", ctx, key, projectID, rk)
+
+	if err := g.s.RateLimiter.Accept(ctx, rk); err != nil {
+		klog.V(4).Infof("GCEBetaForwardingRules.SetLabels(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
+		return err
+	}
+	call := g.s.Beta.ForwardingRules.SetLabels(projectID, key.Region, key.Name, arg0)
+	call.Context(ctx)
+	op, err := call.Do()
+	if err != nil {
+		klog.V(4).Infof("GCEBetaForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+		return err
+	}
+	err = g.s.WaitForCompletion(ctx, op)
+	klog.V(4).Infof("GCEBetaForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+	return err
+}
+
 // SetTarget is a method on GCEBetaForwardingRules.
 func (g *GCEBetaForwardingRules) SetTarget(ctx context.Context, key *meta.Key, arg0 *beta.TargetReference) error {
 	klog.V(5).Infof("GCEBetaForwardingRules.SetTarget(%v, %v, ...): called", ctx, key)
@@ -13018,6 +13147,7 @@ type AlphaGlobalForwardingRules interface {
 	List(ctx context.Context, fl *filter.F) ([]*alpha.ForwardingRule, error)
 	Insert(ctx context.Context, key *meta.Key, obj *alpha.ForwardingRule) error
 	Delete(ctx context.Context, key *meta.Key) error
+	SetLabels(context.Context, *meta.Key, *alpha.GlobalSetLabelsRequest) error
 	SetTarget(context.Context, *meta.Key, *alpha.TargetReference) error
 }
 
@@ -13058,6 +13188,7 @@ type MockAlphaGlobalForwardingRules struct {
 	ListHook      func(ctx context.Context, fl *filter.F, m *MockAlphaGlobalForwardingRules) (bool, []*alpha.ForwardingRule, error)
 	InsertHook    func(ctx context.Context, key *meta.Key, obj *alpha.ForwardingRule, m *MockAlphaGlobalForwardingRules) (bool, error)
 	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockAlphaGlobalForwardingRules) (bool, error)
+	SetLabelsHook func(context.Context, *meta.Key, *alpha.GlobalSetLabelsRequest, *MockAlphaGlobalForwardingRules) error
 	SetTargetHook func(context.Context, *meta.Key, *alpha.TargetReference, *MockAlphaGlobalForwardingRules) error
 
 	// X is extra state that can be used as part of the mock. Generated code
@@ -13202,6 +13333,14 @@ func (m *MockAlphaGlobalForwardingRules) Delete(ctx context.Context, key *meta.K
 // Obj wraps the object for use in the mock.
 func (m *MockAlphaGlobalForwardingRules) Obj(o *alpha.ForwardingRule) *MockGlobalForwardingRulesObj {
 	return &MockGlobalForwardingRulesObj{o}
+}
+
+// SetLabels is a mock for the corresponding method.
+func (m *MockAlphaGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *alpha.GlobalSetLabelsRequest) error {
+	if m.SetLabelsHook != nil {
+		return m.SetLabelsHook(ctx, key, arg0, m)
+	}
+	return nil
 }
 
 // SetTarget is a mock for the corresponding method.
@@ -13354,6 +13493,39 @@ func (g *GCEAlphaGlobalForwardingRules) Delete(ctx context.Context, key *meta.Ke
 	return err
 }
 
+// SetLabels is a method on GCEAlphaGlobalForwardingRules.
+func (g *GCEAlphaGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *alpha.GlobalSetLabelsRequest) error {
+	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.SetLabels(%v, %v, ...): called", ctx, key)
+
+	if !key.Valid() {
+		klog.V(2).Infof("GCEAlphaGlobalForwardingRules.SetLabels(%v, %v, ...): key is invalid (%#v)", ctx, key, key)
+		return fmt.Errorf("invalid GCE key (%+v)", key)
+	}
+	projectID := g.s.ProjectRouter.ProjectID(ctx, "alpha", "GlobalForwardingRules")
+	rk := &RateLimitKey{
+		ProjectID: projectID,
+		Operation: "SetLabels",
+		Version:   meta.Version("alpha"),
+		Service:   "GlobalForwardingRules",
+	}
+	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.SetLabels(%v, %v, ...): projectID = %v, rk = %+v", ctx, key, projectID, rk)
+
+	if err := g.s.RateLimiter.Accept(ctx, rk); err != nil {
+		klog.V(4).Infof("GCEAlphaGlobalForwardingRules.SetLabels(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
+		return err
+	}
+	call := g.s.Alpha.GlobalForwardingRules.SetLabels(projectID, key.Name, arg0)
+	call.Context(ctx)
+	op, err := call.Do()
+	if err != nil {
+		klog.V(4).Infof("GCEAlphaGlobalForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+		return err
+	}
+	err = g.s.WaitForCompletion(ctx, op)
+	klog.V(4).Infof("GCEAlphaGlobalForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+	return err
+}
+
 // SetTarget is a method on GCEAlphaGlobalForwardingRules.
 func (g *GCEAlphaGlobalForwardingRules) SetTarget(ctx context.Context, key *meta.Key, arg0 *alpha.TargetReference) error {
 	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.SetTarget(%v, %v, ...): called", ctx, key)
@@ -13393,6 +13565,7 @@ type BetaGlobalForwardingRules interface {
 	List(ctx context.Context, fl *filter.F) ([]*beta.ForwardingRule, error)
 	Insert(ctx context.Context, key *meta.Key, obj *beta.ForwardingRule) error
 	Delete(ctx context.Context, key *meta.Key) error
+	SetLabels(context.Context, *meta.Key, *beta.GlobalSetLabelsRequest) error
 	SetTarget(context.Context, *meta.Key, *beta.TargetReference) error
 }
 
@@ -13433,6 +13606,7 @@ type MockBetaGlobalForwardingRules struct {
 	ListHook      func(ctx context.Context, fl *filter.F, m *MockBetaGlobalForwardingRules) (bool, []*beta.ForwardingRule, error)
 	InsertHook    func(ctx context.Context, key *meta.Key, obj *beta.ForwardingRule, m *MockBetaGlobalForwardingRules) (bool, error)
 	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockBetaGlobalForwardingRules) (bool, error)
+	SetLabelsHook func(context.Context, *meta.Key, *beta.GlobalSetLabelsRequest, *MockBetaGlobalForwardingRules) error
 	SetTargetHook func(context.Context, *meta.Key, *beta.TargetReference, *MockBetaGlobalForwardingRules) error
 
 	// X is extra state that can be used as part of the mock. Generated code
@@ -13577,6 +13751,14 @@ func (m *MockBetaGlobalForwardingRules) Delete(ctx context.Context, key *meta.Ke
 // Obj wraps the object for use in the mock.
 func (m *MockBetaGlobalForwardingRules) Obj(o *beta.ForwardingRule) *MockGlobalForwardingRulesObj {
 	return &MockGlobalForwardingRulesObj{o}
+}
+
+// SetLabels is a mock for the corresponding method.
+func (m *MockBetaGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *beta.GlobalSetLabelsRequest) error {
+	if m.SetLabelsHook != nil {
+		return m.SetLabelsHook(ctx, key, arg0, m)
+	}
+	return nil
 }
 
 // SetTarget is a mock for the corresponding method.
@@ -13729,6 +13911,39 @@ func (g *GCEBetaGlobalForwardingRules) Delete(ctx context.Context, key *meta.Key
 	return err
 }
 
+// SetLabels is a method on GCEBetaGlobalForwardingRules.
+func (g *GCEBetaGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *beta.GlobalSetLabelsRequest) error {
+	klog.V(5).Infof("GCEBetaGlobalForwardingRules.SetLabels(%v, %v, ...): called", ctx, key)
+
+	if !key.Valid() {
+		klog.V(2).Infof("GCEBetaGlobalForwardingRules.SetLabels(%v, %v, ...): key is invalid (%#v)", ctx, key, key)
+		return fmt.Errorf("invalid GCE key (%+v)", key)
+	}
+	projectID := g.s.ProjectRouter.ProjectID(ctx, "beta", "GlobalForwardingRules")
+	rk := &RateLimitKey{
+		ProjectID: projectID,
+		Operation: "SetLabels",
+		Version:   meta.Version("beta"),
+		Service:   "GlobalForwardingRules",
+	}
+	klog.V(5).Infof("GCEBetaGlobalForwardingRules.SetLabels(%v, %v, ...): projectID = %v, rk = %+v", ctx, key, projectID, rk)
+
+	if err := g.s.RateLimiter.Accept(ctx, rk); err != nil {
+		klog.V(4).Infof("GCEBetaGlobalForwardingRules.SetLabels(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
+		return err
+	}
+	call := g.s.Beta.GlobalForwardingRules.SetLabels(projectID, key.Name, arg0)
+	call.Context(ctx)
+	op, err := call.Do()
+	if err != nil {
+		klog.V(4).Infof("GCEBetaGlobalForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+		return err
+	}
+	err = g.s.WaitForCompletion(ctx, op)
+	klog.V(4).Infof("GCEBetaGlobalForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+	return err
+}
+
 // SetTarget is a method on GCEBetaGlobalForwardingRules.
 func (g *GCEBetaGlobalForwardingRules) SetTarget(ctx context.Context, key *meta.Key, arg0 *beta.TargetReference) error {
 	klog.V(5).Infof("GCEBetaGlobalForwardingRules.SetTarget(%v, %v, ...): called", ctx, key)
@@ -13768,6 +13983,7 @@ type GlobalForwardingRules interface {
 	List(ctx context.Context, fl *filter.F) ([]*ga.ForwardingRule, error)
 	Insert(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule) error
 	Delete(ctx context.Context, key *meta.Key) error
+	SetLabels(context.Context, *meta.Key, *ga.GlobalSetLabelsRequest) error
 	SetTarget(context.Context, *meta.Key, *ga.TargetReference) error
 }
 
@@ -13808,6 +14024,7 @@ type MockGlobalForwardingRules struct {
 	ListHook      func(ctx context.Context, fl *filter.F, m *MockGlobalForwardingRules) (bool, []*ga.ForwardingRule, error)
 	InsertHook    func(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule, m *MockGlobalForwardingRules) (bool, error)
 	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockGlobalForwardingRules) (bool, error)
+	SetLabelsHook func(context.Context, *meta.Key, *ga.GlobalSetLabelsRequest, *MockGlobalForwardingRules) error
 	SetTargetHook func(context.Context, *meta.Key, *ga.TargetReference, *MockGlobalForwardingRules) error
 
 	// X is extra state that can be used as part of the mock. Generated code
@@ -13952,6 +14169,14 @@ func (m *MockGlobalForwardingRules) Delete(ctx context.Context, key *meta.Key) e
 // Obj wraps the object for use in the mock.
 func (m *MockGlobalForwardingRules) Obj(o *ga.ForwardingRule) *MockGlobalForwardingRulesObj {
 	return &MockGlobalForwardingRulesObj{o}
+}
+
+// SetLabels is a mock for the corresponding method.
+func (m *MockGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *ga.GlobalSetLabelsRequest) error {
+	if m.SetLabelsHook != nil {
+		return m.SetLabelsHook(ctx, key, arg0, m)
+	}
+	return nil
 }
 
 // SetTarget is a mock for the corresponding method.
@@ -14101,6 +14326,39 @@ func (g *GCEGlobalForwardingRules) Delete(ctx context.Context, key *meta.Key) er
 
 	err = g.s.WaitForCompletion(ctx, op)
 	klog.V(4).Infof("GCEGlobalForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
+	return err
+}
+
+// SetLabels is a method on GCEGlobalForwardingRules.
+func (g *GCEGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 *ga.GlobalSetLabelsRequest) error {
+	klog.V(5).Infof("GCEGlobalForwardingRules.SetLabels(%v, %v, ...): called", ctx, key)
+
+	if !key.Valid() {
+		klog.V(2).Infof("GCEGlobalForwardingRules.SetLabels(%v, %v, ...): key is invalid (%#v)", ctx, key, key)
+		return fmt.Errorf("invalid GCE key (%+v)", key)
+	}
+	projectID := g.s.ProjectRouter.ProjectID(ctx, "ga", "GlobalForwardingRules")
+	rk := &RateLimitKey{
+		ProjectID: projectID,
+		Operation: "SetLabels",
+		Version:   meta.Version("ga"),
+		Service:   "GlobalForwardingRules",
+	}
+	klog.V(5).Infof("GCEGlobalForwardingRules.SetLabels(%v, %v, ...): projectID = %v, rk = %+v", ctx, key, projectID, rk)
+
+	if err := g.s.RateLimiter.Accept(ctx, rk); err != nil {
+		klog.V(4).Infof("GCEGlobalForwardingRules.SetLabels(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
+		return err
+	}
+	call := g.s.GA.GlobalForwardingRules.SetLabels(projectID, key.Name, arg0)
+	call.Context(ctx)
+	op, err := call.Do()
+	if err != nil {
+		klog.V(4).Infof("GCEGlobalForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
+		return err
+	}
+	err = g.s.WaitForCompletion(ctx, op)
+	klog.V(4).Infof("GCEGlobalForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 	return err
 }
 

--- a/pkg/cloud/meta/meta.go
+++ b/pkg/cloud/meta/meta.go
@@ -306,6 +306,7 @@ var AllServices = []*ServiceInfo{
 		serviceType: reflect.TypeOf(&ga.ForwardingRulesService{}),
 		additionalMethods: []string{
 			"SetTarget",
+			"SetLabels",
 		},
 	},
 	{
@@ -317,6 +318,7 @@ var AllServices = []*ServiceInfo{
 		serviceType: reflect.TypeOf(&alpha.ForwardingRulesService{}),
 		additionalMethods: []string{
 			"SetTarget",
+			"SetLabels",
 		},
 	},
 	{
@@ -328,6 +330,7 @@ var AllServices = []*ServiceInfo{
 		serviceType: reflect.TypeOf(&beta.ForwardingRulesService{}),
 		additionalMethods: []string{
 			"SetTarget",
+			"SetLabels",
 		},
 	},
 	{
@@ -339,6 +342,7 @@ var AllServices = []*ServiceInfo{
 		serviceType: reflect.TypeOf(&alpha.GlobalForwardingRulesService{}),
 		additionalMethods: []string{
 			"SetTarget",
+			"SetLabels",
 		},
 	},
 	{
@@ -350,6 +354,7 @@ var AllServices = []*ServiceInfo{
 		serviceType: reflect.TypeOf(&beta.GlobalForwardingRulesService{}),
 		additionalMethods: []string{
 			"SetTarget",
+			"SetLabels",
 		},
 	},
 	{
@@ -360,6 +365,7 @@ var AllServices = []*ServiceInfo{
 		serviceType: reflect.TypeOf(&ga.GlobalForwardingRulesService{}),
 		additionalMethods: []string{
 			"SetTarget",
+			"SetLabels",
 		},
 	},
 	{


### PR DESCRIPTION
This is required to set or modify the `labels` field on a ForwardingRule