### PR TITLE
Extend RateLimiter interface with observe functionality

### DIFF
--- a/pkg/cloud/gce_projects.go
+++ b/pkg/cloud/gce_projects.go
@@ -64,7 +64,9 @@ func (g *GCEProjects) Get(ctx context.Context, projectID string) (*compute.Proje
 	}
 	call := g.s.GA.Projects.Get(projectID)
 	call.Context(ctx)
-	return call.Do()
+	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
+	return v, err
 }
 
 // SetCommonInstanceMetadata for a given project.
@@ -92,6 +94,7 @@ func (g *GCEProjects) SetCommonInstanceMetadata(ctx context.Context, projectID s
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/gen.go
+++ b/pkg/cloud/gen.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Google LLC
+Copyright 2023 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -3133,6 +3133,7 @@ func (g *GCEAddresses) Get(ctx context.Context, key *meta.Key) (*ga.Address, err
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAddresses.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -3161,10 +3162,12 @@ func (g *GCEAddresses) List(ctx context.Context, region string, fl *filter.F) ([
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAddresses.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAddresses.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -3202,6 +3205,7 @@ func (g *GCEAddresses) Insert(ctx context.Context, key *meta.Key, obj *ga.Addres
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAddresses.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -3235,6 +3239,7 @@ func (g *GCEAddresses) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAddresses.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -3278,6 +3283,7 @@ func (g *GCEAddresses) AggregatedList(ctx context.Context, fl *filter.F) (map[st
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAddresses.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -3553,6 +3559,7 @@ func (g *GCEAlphaAddresses) Get(ctx context.Context, key *meta.Key) (*alpha.Addr
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaAddresses.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -3581,10 +3588,12 @@ func (g *GCEAlphaAddresses) List(ctx context.Context, region string, fl *filter.
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaAddresses.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaAddresses.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -3622,6 +3631,7 @@ func (g *GCEAlphaAddresses) Insert(ctx context.Context, key *meta.Key, obj *alph
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaAddresses.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -3655,6 +3665,7 @@ func (g *GCEAlphaAddresses) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaAddresses.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -3698,6 +3709,7 @@ func (g *GCEAlphaAddresses) AggregatedList(ctx context.Context, fl *filter.F) (m
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaAddresses.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -3973,6 +3985,7 @@ func (g *GCEBetaAddresses) Get(ctx context.Context, key *meta.Key) (*beta.Addres
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaAddresses.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -4001,10 +4014,12 @@ func (g *GCEBetaAddresses) List(ctx context.Context, region string, fl *filter.F
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaAddresses.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaAddresses.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -4042,6 +4057,7 @@ func (g *GCEBetaAddresses) Insert(ctx context.Context, key *meta.Key, obj *beta.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaAddresses.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -4075,6 +4091,7 @@ func (g *GCEBetaAddresses) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaAddresses.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -4118,6 +4135,7 @@ func (g *GCEBetaAddresses) AggregatedList(ctx context.Context, fl *filter.F) (ma
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaAddresses.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -4352,6 +4370,7 @@ func (g *GCEAlphaGlobalAddresses) Get(ctx context.Context, key *meta.Key) (*alph
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaGlobalAddresses.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -4380,10 +4399,12 @@ func (g *GCEAlphaGlobalAddresses) List(ctx context.Context, fl *filter.F) ([]*al
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaGlobalAddresses.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaGlobalAddresses.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -4421,6 +4442,7 @@ func (g *GCEAlphaGlobalAddresses) Insert(ctx context.Context, key *meta.Key, obj
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaGlobalAddresses.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -4455,6 +4477,7 @@ func (g *GCEAlphaGlobalAddresses) Delete(ctx context.Context, key *meta.Key) err
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaGlobalAddresses.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -4684,6 +4707,7 @@ func (g *GCEBetaGlobalAddresses) Get(ctx context.Context, key *meta.Key) (*beta.
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaGlobalAddresses.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -4712,10 +4736,12 @@ func (g *GCEBetaGlobalAddresses) List(ctx context.Context, fl *filter.F) ([]*bet
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaGlobalAddresses.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaGlobalAddresses.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -4753,6 +4779,7 @@ func (g *GCEBetaGlobalAddresses) Insert(ctx context.Context, key *meta.Key, obj 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaGlobalAddresses.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -4787,6 +4814,7 @@ func (g *GCEBetaGlobalAddresses) Delete(ctx context.Context, key *meta.Key) erro
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaGlobalAddresses.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -5016,6 +5044,7 @@ func (g *GCEGlobalAddresses) Get(ctx context.Context, key *meta.Key) (*ga.Addres
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEGlobalAddresses.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -5044,10 +5073,12 @@ func (g *GCEGlobalAddresses) List(ctx context.Context, fl *filter.F) ([]*ga.Addr
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEGlobalAddresses.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEGlobalAddresses.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -5085,6 +5116,7 @@ func (g *GCEGlobalAddresses) Insert(ctx context.Context, key *meta.Key, obj *ga.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEGlobalAddresses.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -5119,6 +5151,7 @@ func (g *GCEGlobalAddresses) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEGlobalAddresses.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -5446,6 +5479,7 @@ func (g *GCEBackendServices) Get(ctx context.Context, key *meta.Key) (*ga.Backen
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBackendServices.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -5474,10 +5508,12 @@ func (g *GCEBackendServices) List(ctx context.Context, fl *filter.F) ([]*ga.Back
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBackendServices.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBackendServices.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -5515,6 +5551,7 @@ func (g *GCEBackendServices) Insert(ctx context.Context, key *meta.Key, obj *ga.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBackendServices.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -5549,6 +5586,7 @@ func (g *GCEBackendServices) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -5592,6 +5630,7 @@ func (g *GCEBackendServices) AggregatedList(ctx context.Context, fl *filter.F) (
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBackendServices.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -5631,6 +5670,7 @@ func (g *GCEBackendServices) AddSignedUrlKey(ctx context.Context, key *meta.Key,
 	call := g.s.GA.BackendServices.AddSignedUrlKey(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBackendServices.AddSignedUrlKey(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -5664,6 +5704,7 @@ func (g *GCEBackendServices) DeleteSignedUrlKey(ctx context.Context, key *meta.K
 	call := g.s.GA.BackendServices.DeleteSignedUrlKey(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBackendServices.DeleteSignedUrlKey(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -5697,6 +5738,7 @@ func (g *GCEBackendServices) GetHealth(ctx context.Context, key *meta.Key, arg0 
 	call := g.s.GA.BackendServices.GetHealth(projectID, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBackendServices.GetHealth(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -5725,6 +5767,7 @@ func (g *GCEBackendServices) Patch(ctx context.Context, key *meta.Key, arg0 *ga.
 	call := g.s.GA.BackendServices.Patch(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBackendServices.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -5758,6 +5801,7 @@ func (g *GCEBackendServices) SetSecurityPolicy(ctx context.Context, key *meta.Ke
 	call := g.s.GA.BackendServices.SetSecurityPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBackendServices.SetSecurityPolicy(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -5791,6 +5835,7 @@ func (g *GCEBackendServices) Update(ctx context.Context, key *meta.Key, arg0 *ga
 	call := g.s.GA.BackendServices.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBackendServices.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6097,6 +6142,7 @@ func (g *GCEBetaBackendServices) Get(ctx context.Context, key *meta.Key) (*beta.
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaBackendServices.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -6125,10 +6171,12 @@ func (g *GCEBetaBackendServices) List(ctx context.Context, fl *filter.F) ([]*bet
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaBackendServices.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaBackendServices.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -6166,6 +6214,7 @@ func (g *GCEBetaBackendServices) Insert(ctx context.Context, key *meta.Key, obj 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaBackendServices.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6200,6 +6249,7 @@ func (g *GCEBetaBackendServices) Delete(ctx context.Context, key *meta.Key) erro
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -6243,6 +6293,7 @@ func (g *GCEBetaBackendServices) AggregatedList(ctx context.Context, fl *filter.
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaBackendServices.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -6282,6 +6333,7 @@ func (g *GCEBetaBackendServices) AddSignedUrlKey(ctx context.Context, key *meta.
 	call := g.s.Beta.BackendServices.AddSignedUrlKey(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaBackendServices.AddSignedUrlKey(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6315,6 +6367,7 @@ func (g *GCEBetaBackendServices) DeleteSignedUrlKey(ctx context.Context, key *me
 	call := g.s.Beta.BackendServices.DeleteSignedUrlKey(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaBackendServices.DeleteSignedUrlKey(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6348,6 +6401,7 @@ func (g *GCEBetaBackendServices) SetSecurityPolicy(ctx context.Context, key *met
 	call := g.s.Beta.BackendServices.SetSecurityPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaBackendServices.SetSecurityPolicy(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6381,6 +6435,7 @@ func (g *GCEBetaBackendServices) Update(ctx context.Context, key *meta.Key, arg0
 	call := g.s.Beta.BackendServices.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaBackendServices.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6687,6 +6742,7 @@ func (g *GCEAlphaBackendServices) Get(ctx context.Context, key *meta.Key) (*alph
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaBackendServices.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -6715,10 +6771,12 @@ func (g *GCEAlphaBackendServices) List(ctx context.Context, fl *filter.F) ([]*al
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaBackendServices.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaBackendServices.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -6756,6 +6814,7 @@ func (g *GCEAlphaBackendServices) Insert(ctx context.Context, key *meta.Key, obj
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaBackendServices.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6790,6 +6849,7 @@ func (g *GCEAlphaBackendServices) Delete(ctx context.Context, key *meta.Key) err
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -6833,6 +6893,7 @@ func (g *GCEAlphaBackendServices) AggregatedList(ctx context.Context, fl *filter
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaBackendServices.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -6872,6 +6933,7 @@ func (g *GCEAlphaBackendServices) AddSignedUrlKey(ctx context.Context, key *meta
 	call := g.s.Alpha.BackendServices.AddSignedUrlKey(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaBackendServices.AddSignedUrlKey(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6905,6 +6967,7 @@ func (g *GCEAlphaBackendServices) DeleteSignedUrlKey(ctx context.Context, key *m
 	call := g.s.Alpha.BackendServices.DeleteSignedUrlKey(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaBackendServices.DeleteSignedUrlKey(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6938,6 +7001,7 @@ func (g *GCEAlphaBackendServices) SetSecurityPolicy(ctx context.Context, key *me
 	call := g.s.Alpha.BackendServices.SetSecurityPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaBackendServices.SetSecurityPolicy(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -6971,6 +7035,7 @@ func (g *GCEAlphaBackendServices) Update(ctx context.Context, key *meta.Key, arg
 	call := g.s.Alpha.BackendServices.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaBackendServices.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -7222,6 +7287,7 @@ func (g *GCERegionBackendServices) Get(ctx context.Context, key *meta.Key) (*ga.
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERegionBackendServices.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -7250,10 +7316,12 @@ func (g *GCERegionBackendServices) List(ctx context.Context, region string, fl *
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERegionBackendServices.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERegionBackendServices.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -7291,6 +7359,7 @@ func (g *GCERegionBackendServices) Insert(ctx context.Context, key *meta.Key, ob
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionBackendServices.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -7324,6 +7393,7 @@ func (g *GCERegionBackendServices) Delete(ctx context.Context, key *meta.Key) er
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -7358,6 +7428,7 @@ func (g *GCERegionBackendServices) GetHealth(ctx context.Context, key *meta.Key,
 	call := g.s.GA.RegionBackendServices.GetHealth(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCERegionBackendServices.GetHealth(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -7386,6 +7457,7 @@ func (g *GCERegionBackendServices) Update(ctx context.Context, key *meta.Key, ar
 	call := g.s.GA.RegionBackendServices.Update(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionBackendServices.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -7637,6 +7709,7 @@ func (g *GCEAlphaRegionBackendServices) Get(ctx context.Context, key *meta.Key) 
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaRegionBackendServices.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -7665,10 +7738,12 @@ func (g *GCEAlphaRegionBackendServices) List(ctx context.Context, region string,
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaRegionBackendServices.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaRegionBackendServices.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -7706,6 +7781,7 @@ func (g *GCEAlphaRegionBackendServices) Insert(ctx context.Context, key *meta.Ke
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionBackendServices.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -7739,6 +7815,7 @@ func (g *GCEAlphaRegionBackendServices) Delete(ctx context.Context, key *meta.Ke
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -7773,6 +7850,7 @@ func (g *GCEAlphaRegionBackendServices) GetHealth(ctx context.Context, key *meta
 	call := g.s.Alpha.RegionBackendServices.GetHealth(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaRegionBackendServices.GetHealth(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -7801,6 +7879,7 @@ func (g *GCEAlphaRegionBackendServices) Update(ctx context.Context, key *meta.Ke
 	call := g.s.Alpha.RegionBackendServices.Update(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionBackendServices.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -8052,6 +8131,7 @@ func (g *GCEBetaRegionBackendServices) Get(ctx context.Context, key *meta.Key) (
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaRegionBackendServices.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -8080,10 +8160,12 @@ func (g *GCEBetaRegionBackendServices) List(ctx context.Context, region string, 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaRegionBackendServices.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaRegionBackendServices.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -8121,6 +8203,7 @@ func (g *GCEBetaRegionBackendServices) Insert(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionBackendServices.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -8154,6 +8237,7 @@ func (g *GCEBetaRegionBackendServices) Delete(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -8188,6 +8272,7 @@ func (g *GCEBetaRegionBackendServices) GetHealth(ctx context.Context, key *meta.
 	call := g.s.Beta.RegionBackendServices.GetHealth(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBetaRegionBackendServices.GetHealth(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -8216,6 +8301,7 @@ func (g *GCEBetaRegionBackendServices) Update(ctx context.Context, key *meta.Key
 	call := g.s.Beta.RegionBackendServices.Update(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionBackendServices.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -8457,6 +8543,7 @@ func (g *GCEDisks) Get(ctx context.Context, key *meta.Key) (*ga.Disk, error) {
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEDisks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -8485,10 +8572,12 @@ func (g *GCEDisks) List(ctx context.Context, zone string, fl *filter.F) ([]*ga.D
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEDisks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEDisks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -8526,6 +8615,7 @@ func (g *GCEDisks) Insert(ctx context.Context, key *meta.Key, obj *ga.Disk) erro
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEDisks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -8559,6 +8649,7 @@ func (g *GCEDisks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEDisks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -8593,6 +8684,7 @@ func (g *GCEDisks) Resize(ctx context.Context, key *meta.Key, arg0 *ga.DisksResi
 	call := g.s.GA.Disks.Resize(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEDisks.Resize(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -8834,6 +8926,7 @@ func (g *GCERegionDisks) Get(ctx context.Context, key *meta.Key) (*ga.Disk, erro
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERegionDisks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -8862,10 +8955,12 @@ func (g *GCERegionDisks) List(ctx context.Context, region string, fl *filter.F) 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERegionDisks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERegionDisks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -8903,6 +8998,7 @@ func (g *GCERegionDisks) Insert(ctx context.Context, key *meta.Key, obj *ga.Disk
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionDisks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -8936,6 +9032,7 @@ func (g *GCERegionDisks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionDisks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -8970,6 +9067,7 @@ func (g *GCERegionDisks) Resize(ctx context.Context, key *meta.Key, arg0 *ga.Reg
 	call := g.s.GA.RegionDisks.Resize(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionDisks.Resize(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -9218,6 +9316,7 @@ func (g *GCEAlphaFirewalls) Get(ctx context.Context, key *meta.Key) (*alpha.Fire
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaFirewalls.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -9246,10 +9345,12 @@ func (g *GCEAlphaFirewalls) List(ctx context.Context, fl *filter.F) ([]*alpha.Fi
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaFirewalls.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaFirewalls.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -9287,6 +9388,7 @@ func (g *GCEAlphaFirewalls) Insert(ctx context.Context, key *meta.Key, obj *alph
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaFirewalls.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -9321,6 +9423,7 @@ func (g *GCEAlphaFirewalls) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaFirewalls.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -9355,6 +9458,7 @@ func (g *GCEAlphaFirewalls) Patch(ctx context.Context, key *meta.Key, arg0 *alph
 	call := g.s.Alpha.Firewalls.Patch(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaFirewalls.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -9388,6 +9492,7 @@ func (g *GCEAlphaFirewalls) Update(ctx context.Context, key *meta.Key, arg0 *alp
 	call := g.s.Alpha.Firewalls.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaFirewalls.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -9636,6 +9741,7 @@ func (g *GCEBetaFirewalls) Get(ctx context.Context, key *meta.Key) (*beta.Firewa
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaFirewalls.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -9664,10 +9770,12 @@ func (g *GCEBetaFirewalls) List(ctx context.Context, fl *filter.F) ([]*beta.Fire
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaFirewalls.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaFirewalls.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -9705,6 +9813,7 @@ func (g *GCEBetaFirewalls) Insert(ctx context.Context, key *meta.Key, obj *beta.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaFirewalls.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -9739,6 +9848,7 @@ func (g *GCEBetaFirewalls) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaFirewalls.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -9773,6 +9883,7 @@ func (g *GCEBetaFirewalls) Patch(ctx context.Context, key *meta.Key, arg0 *beta.
 	call := g.s.Beta.Firewalls.Patch(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaFirewalls.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -9806,6 +9917,7 @@ func (g *GCEBetaFirewalls) Update(ctx context.Context, key *meta.Key, arg0 *beta
 	call := g.s.Beta.Firewalls.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaFirewalls.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10054,6 +10166,7 @@ func (g *GCEFirewalls) Get(ctx context.Context, key *meta.Key) (*ga.Firewall, er
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEFirewalls.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -10082,10 +10195,12 @@ func (g *GCEFirewalls) List(ctx context.Context, fl *filter.F) ([]*ga.Firewall, 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEFirewalls.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEFirewalls.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -10123,6 +10238,7 @@ func (g *GCEFirewalls) Insert(ctx context.Context, key *meta.Key, obj *ga.Firewa
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEFirewalls.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10157,6 +10273,7 @@ func (g *GCEFirewalls) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEFirewalls.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -10191,6 +10308,7 @@ func (g *GCEFirewalls) Patch(ctx context.Context, key *meta.Key, arg0 *ga.Firewa
 	call := g.s.GA.Firewalls.Patch(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEFirewalls.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10224,6 +10342,7 @@ func (g *GCEFirewalls) Update(ctx context.Context, key *meta.Key, arg0 *ga.Firew
 	call := g.s.GA.Firewalls.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEFirewalls.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10572,6 +10691,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) Get(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -10600,10 +10720,12 @@ func (g *GCEAlphaNetworkFirewallPolicies) List(ctx context.Context, fl *filter.F
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -10641,6 +10763,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) Insert(ctx context.Context, key *meta.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10675,6 +10798,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) Delete(ctx context.Context, key *meta.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -10709,6 +10833,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) AddAssociation(ctx context.Context, ke
 	call := g.s.Alpha.NetworkFirewallPolicies.AddAssociation(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.AddAssociation(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10742,6 +10867,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) AddRule(ctx context.Context, key *meta
 	call := g.s.Alpha.NetworkFirewallPolicies.AddRule(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.AddRule(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10775,6 +10901,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) CloneRules(ctx context.Context, key *m
 	call := g.s.Alpha.NetworkFirewallPolicies.CloneRules(projectID, key.Name)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.CloneRules(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10808,6 +10935,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) GetAssociation(ctx context.Context, ke
 	call := g.s.Alpha.NetworkFirewallPolicies.GetAssociation(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.GetAssociation(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -10836,6 +10964,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) GetIamPolicy(ctx context.Context, key 
 	call := g.s.Alpha.NetworkFirewallPolicies.GetIamPolicy(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.GetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -10864,6 +10993,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) GetRule(ctx context.Context, key *meta
 	call := g.s.Alpha.NetworkFirewallPolicies.GetRule(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.GetRule(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -10892,6 +11022,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) Patch(ctx context.Context, key *meta.K
 	call := g.s.Alpha.NetworkFirewallPolicies.Patch(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10925,6 +11056,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) PatchRule(ctx context.Context, key *me
 	call := g.s.Alpha.NetworkFirewallPolicies.PatchRule(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.PatchRule(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10958,6 +11090,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) RemoveAssociation(ctx context.Context,
 	call := g.s.Alpha.NetworkFirewallPolicies.RemoveAssociation(projectID, key.Name)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.RemoveAssociation(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -10991,6 +11124,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) RemoveRule(ctx context.Context, key *m
 	call := g.s.Alpha.NetworkFirewallPolicies.RemoveRule(projectID, key.Name)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.RemoveRule(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -11024,6 +11158,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) SetIamPolicy(ctx context.Context, key 
 	call := g.s.Alpha.NetworkFirewallPolicies.SetIamPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.SetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -11052,6 +11187,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) TestIamPermissions(ctx context.Context
 	call := g.s.Alpha.NetworkFirewallPolicies.TestIamPermissions(projectID, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaNetworkFirewallPolicies.TestIamPermissions(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -11398,6 +11534,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) Get(ctx context.Context, key *me
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -11426,10 +11563,12 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) List(ctx context.Context, region
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -11467,6 +11606,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) Insert(ctx context.Context, key 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -11500,6 +11640,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) Delete(ctx context.Context, key 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -11534,6 +11675,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) AddAssociation(ctx context.Conte
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.AddAssociation(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.AddAssociation(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -11567,6 +11709,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) AddRule(ctx context.Context, key
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.AddRule(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.AddRule(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -11600,6 +11743,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) CloneRules(ctx context.Context, 
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.CloneRules(projectID, key.Region, key.Name)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.CloneRules(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -11633,6 +11777,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) GetAssociation(ctx context.Conte
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.GetAssociation(projectID, key.Region, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.GetAssociation(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -11661,6 +11806,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) GetIamPolicy(ctx context.Context
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.GetIamPolicy(projectID, key.Region, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.GetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -11689,6 +11835,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) GetRule(ctx context.Context, key
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.GetRule(projectID, key.Region, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.GetRule(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -11717,6 +11864,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) Patch(ctx context.Context, key *
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -11750,6 +11898,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) PatchRule(ctx context.Context, k
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.PatchRule(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.PatchRule(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -11783,6 +11932,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) RemoveAssociation(ctx context.Co
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.RemoveAssociation(projectID, key.Region, key.Name)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.RemoveAssociation(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -11816,6 +11966,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) RemoveRule(ctx context.Context, 
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.RemoveRule(projectID, key.Region, key.Name)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.RemoveRule(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -11849,6 +12000,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) SetIamPolicy(ctx context.Context
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.SetIamPolicy(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.SetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -11877,6 +12029,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) TestIamPermissions(ctx context.C
 	call := g.s.Alpha.RegionNetworkFirewallPolicies.TestIamPermissions(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaRegionNetworkFirewallPolicies.TestIamPermissions(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -12123,6 +12276,7 @@ func (g *GCEForwardingRules) Get(ctx context.Context, key *meta.Key) (*ga.Forwar
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEForwardingRules.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -12151,10 +12305,12 @@ func (g *GCEForwardingRules) List(ctx context.Context, region string, fl *filter
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEForwardingRules.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEForwardingRules.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -12192,6 +12348,7 @@ func (g *GCEForwardingRules) Insert(ctx context.Context, key *meta.Key, obj *ga.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEForwardingRules.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -12225,6 +12382,7 @@ func (g *GCEForwardingRules) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -12259,6 +12417,7 @@ func (g *GCEForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 
 	call := g.s.GA.ForwardingRules.SetLabels(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -12292,6 +12451,7 @@ func (g *GCEForwardingRules) SetTarget(ctx context.Context, key *meta.Key, arg0 
 	call := g.s.GA.ForwardingRules.SetTarget(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEForwardingRules.SetTarget(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -12543,6 +12703,7 @@ func (g *GCEAlphaForwardingRules) Get(ctx context.Context, key *meta.Key) (*alph
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaForwardingRules.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -12571,10 +12732,12 @@ func (g *GCEAlphaForwardingRules) List(ctx context.Context, region string, fl *f
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaForwardingRules.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaForwardingRules.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -12612,6 +12775,7 @@ func (g *GCEAlphaForwardingRules) Insert(ctx context.Context, key *meta.Key, obj
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaForwardingRules.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -12645,6 +12809,7 @@ func (g *GCEAlphaForwardingRules) Delete(ctx context.Context, key *meta.Key) err
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -12679,6 +12844,7 @@ func (g *GCEAlphaForwardingRules) SetLabels(ctx context.Context, key *meta.Key, 
 	call := g.s.Alpha.ForwardingRules.SetLabels(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -12712,6 +12878,7 @@ func (g *GCEAlphaForwardingRules) SetTarget(ctx context.Context, key *meta.Key, 
 	call := g.s.Alpha.ForwardingRules.SetTarget(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaForwardingRules.SetTarget(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -12963,6 +13130,7 @@ func (g *GCEBetaForwardingRules) Get(ctx context.Context, key *meta.Key) (*beta.
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaForwardingRules.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -12991,10 +13159,12 @@ func (g *GCEBetaForwardingRules) List(ctx context.Context, region string, fl *fi
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaForwardingRules.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaForwardingRules.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -13032,6 +13202,7 @@ func (g *GCEBetaForwardingRules) Insert(ctx context.Context, key *meta.Key, obj 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaForwardingRules.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -13065,6 +13236,7 @@ func (g *GCEBetaForwardingRules) Delete(ctx context.Context, key *meta.Key) erro
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -13099,6 +13271,7 @@ func (g *GCEBetaForwardingRules) SetLabels(ctx context.Context, key *meta.Key, a
 	call := g.s.Beta.ForwardingRules.SetLabels(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -13132,6 +13305,7 @@ func (g *GCEBetaForwardingRules) SetTarget(ctx context.Context, key *meta.Key, a
 	call := g.s.Beta.ForwardingRules.SetTarget(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaForwardingRules.SetTarget(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -13380,6 +13554,7 @@ func (g *GCEAlphaGlobalForwardingRules) Get(ctx context.Context, key *meta.Key) 
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaGlobalForwardingRules.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -13408,10 +13583,12 @@ func (g *GCEAlphaGlobalForwardingRules) List(ctx context.Context, fl *filter.F) 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaGlobalForwardingRules.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaGlobalForwardingRules.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -13449,6 +13626,7 @@ func (g *GCEAlphaGlobalForwardingRules) Insert(ctx context.Context, key *meta.Ke
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaGlobalForwardingRules.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -13483,6 +13661,7 @@ func (g *GCEAlphaGlobalForwardingRules) Delete(ctx context.Context, key *meta.Ke
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaGlobalForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -13517,6 +13696,7 @@ func (g *GCEAlphaGlobalForwardingRules) SetLabels(ctx context.Context, key *meta
 	call := g.s.Alpha.GlobalForwardingRules.SetLabels(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaGlobalForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -13550,6 +13730,7 @@ func (g *GCEAlphaGlobalForwardingRules) SetTarget(ctx context.Context, key *meta
 	call := g.s.Alpha.GlobalForwardingRules.SetTarget(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaGlobalForwardingRules.SetTarget(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -13798,6 +13979,7 @@ func (g *GCEBetaGlobalForwardingRules) Get(ctx context.Context, key *meta.Key) (
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaGlobalForwardingRules.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -13826,10 +14008,12 @@ func (g *GCEBetaGlobalForwardingRules) List(ctx context.Context, fl *filter.F) (
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaGlobalForwardingRules.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaGlobalForwardingRules.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -13867,6 +14051,7 @@ func (g *GCEBetaGlobalForwardingRules) Insert(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaGlobalForwardingRules.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -13901,6 +14086,7 @@ func (g *GCEBetaGlobalForwardingRules) Delete(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaGlobalForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -13935,6 +14121,7 @@ func (g *GCEBetaGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.
 	call := g.s.Beta.GlobalForwardingRules.SetLabels(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaGlobalForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -13968,6 +14155,7 @@ func (g *GCEBetaGlobalForwardingRules) SetTarget(ctx context.Context, key *meta.
 	call := g.s.Beta.GlobalForwardingRules.SetTarget(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaGlobalForwardingRules.SetTarget(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -14216,6 +14404,7 @@ func (g *GCEGlobalForwardingRules) Get(ctx context.Context, key *meta.Key) (*ga.
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEGlobalForwardingRules.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -14244,10 +14433,12 @@ func (g *GCEGlobalForwardingRules) List(ctx context.Context, fl *filter.F) ([]*g
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEGlobalForwardingRules.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEGlobalForwardingRules.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -14285,6 +14476,7 @@ func (g *GCEGlobalForwardingRules) Insert(ctx context.Context, key *meta.Key, ob
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEGlobalForwardingRules.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -14319,6 +14511,7 @@ func (g *GCEGlobalForwardingRules) Delete(ctx context.Context, key *meta.Key) er
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEGlobalForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -14353,6 +14546,7 @@ func (g *GCEGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.Key,
 	call := g.s.GA.GlobalForwardingRules.SetLabels(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEGlobalForwardingRules.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -14386,6 +14580,7 @@ func (g *GCEGlobalForwardingRules) SetTarget(ctx context.Context, key *meta.Key,
 	call := g.s.GA.GlobalForwardingRules.SetTarget(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEGlobalForwardingRules.SetTarget(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -14624,6 +14819,7 @@ func (g *GCEHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.HealthChe
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEHealthChecks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -14652,10 +14848,12 @@ func (g *GCEHealthChecks) List(ctx context.Context, fl *filter.F) ([]*ga.HealthC
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEHealthChecks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEHealthChecks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -14693,6 +14891,7 @@ func (g *GCEHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *ga.Hea
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEHealthChecks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -14727,6 +14926,7 @@ func (g *GCEHealthChecks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -14761,6 +14961,7 @@ func (g *GCEHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *ga.He
 	call := g.s.GA.HealthChecks.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEHealthChecks.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -14999,6 +15200,7 @@ func (g *GCEAlphaHealthChecks) Get(ctx context.Context, key *meta.Key) (*alpha.H
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaHealthChecks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -15027,10 +15229,12 @@ func (g *GCEAlphaHealthChecks) List(ctx context.Context, fl *filter.F) ([]*alpha
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaHealthChecks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaHealthChecks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -15068,6 +15272,7 @@ func (g *GCEAlphaHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *a
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaHealthChecks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -15102,6 +15307,7 @@ func (g *GCEAlphaHealthChecks) Delete(ctx context.Context, key *meta.Key) error 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -15136,6 +15342,7 @@ func (g *GCEAlphaHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *
 	call := g.s.Alpha.HealthChecks.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaHealthChecks.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -15374,6 +15581,7 @@ func (g *GCEBetaHealthChecks) Get(ctx context.Context, key *meta.Key) (*beta.Hea
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaHealthChecks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -15402,10 +15610,12 @@ func (g *GCEBetaHealthChecks) List(ctx context.Context, fl *filter.F) ([]*beta.H
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaHealthChecks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaHealthChecks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -15443,6 +15653,7 @@ func (g *GCEBetaHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *be
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaHealthChecks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -15477,6 +15688,7 @@ func (g *GCEBetaHealthChecks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -15511,6 +15723,7 @@ func (g *GCEBetaHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *b
 	call := g.s.Beta.HealthChecks.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaHealthChecks.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -15752,6 +15965,7 @@ func (g *GCEAlphaRegionHealthChecks) Get(ctx context.Context, key *meta.Key) (*a
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaRegionHealthChecks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -15780,10 +15994,12 @@ func (g *GCEAlphaRegionHealthChecks) List(ctx context.Context, region string, fl
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaRegionHealthChecks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaRegionHealthChecks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -15821,6 +16037,7 @@ func (g *GCEAlphaRegionHealthChecks) Insert(ctx context.Context, key *meta.Key, 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionHealthChecks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -15854,6 +16071,7 @@ func (g *GCEAlphaRegionHealthChecks) Delete(ctx context.Context, key *meta.Key) 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -15888,6 +16106,7 @@ func (g *GCEAlphaRegionHealthChecks) Update(ctx context.Context, key *meta.Key, 
 	call := g.s.Alpha.RegionHealthChecks.Update(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionHealthChecks.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -16129,6 +16348,7 @@ func (g *GCEBetaRegionHealthChecks) Get(ctx context.Context, key *meta.Key) (*be
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaRegionHealthChecks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -16157,10 +16377,12 @@ func (g *GCEBetaRegionHealthChecks) List(ctx context.Context, region string, fl 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaRegionHealthChecks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaRegionHealthChecks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -16198,6 +16420,7 @@ func (g *GCEBetaRegionHealthChecks) Insert(ctx context.Context, key *meta.Key, o
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionHealthChecks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -16231,6 +16454,7 @@ func (g *GCEBetaRegionHealthChecks) Delete(ctx context.Context, key *meta.Key) e
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -16265,6 +16489,7 @@ func (g *GCEBetaRegionHealthChecks) Update(ctx context.Context, key *meta.Key, a
 	call := g.s.Beta.RegionHealthChecks.Update(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionHealthChecks.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -16506,6 +16731,7 @@ func (g *GCERegionHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.Hea
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERegionHealthChecks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -16534,10 +16760,12 @@ func (g *GCERegionHealthChecks) List(ctx context.Context, region string, fl *fil
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERegionHealthChecks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERegionHealthChecks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -16575,6 +16803,7 @@ func (g *GCERegionHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionHealthChecks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -16608,6 +16837,7 @@ func (g *GCERegionHealthChecks) Delete(ctx context.Context, key *meta.Key) error
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -16642,6 +16872,7 @@ func (g *GCERegionHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 
 	call := g.s.GA.RegionHealthChecks.Update(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionHealthChecks.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -16880,6 +17111,7 @@ func (g *GCEHttpHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.HttpH
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEHttpHealthChecks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -16908,10 +17140,12 @@ func (g *GCEHttpHealthChecks) List(ctx context.Context, fl *filter.F) ([]*ga.Htt
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEHttpHealthChecks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEHttpHealthChecks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -16949,6 +17183,7 @@ func (g *GCEHttpHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *ga
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEHttpHealthChecks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -16983,6 +17218,7 @@ func (g *GCEHttpHealthChecks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEHttpHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -17017,6 +17253,7 @@ func (g *GCEHttpHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *g
 	call := g.s.GA.HttpHealthChecks.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEHttpHealthChecks.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -17255,6 +17492,7 @@ func (g *GCEHttpsHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.Http
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEHttpsHealthChecks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -17283,10 +17521,12 @@ func (g *GCEHttpsHealthChecks) List(ctx context.Context, fl *filter.F) ([]*ga.Ht
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEHttpsHealthChecks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEHttpsHealthChecks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -17324,6 +17564,7 @@ func (g *GCEHttpsHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *g
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEHttpsHealthChecks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -17358,6 +17599,7 @@ func (g *GCEHttpsHealthChecks) Delete(ctx context.Context, key *meta.Key) error 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEHttpsHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -17392,6 +17634,7 @@ func (g *GCEHttpsHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *
 	call := g.s.GA.HttpsHealthChecks.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEHttpsHealthChecks.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -17663,6 +17906,7 @@ func (g *GCEInstanceGroups) Get(ctx context.Context, key *meta.Key) (*ga.Instanc
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEInstanceGroups.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -17691,10 +17935,12 @@ func (g *GCEInstanceGroups) List(ctx context.Context, zone string, fl *filter.F)
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEInstanceGroups.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEInstanceGroups.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -17732,6 +17978,7 @@ func (g *GCEInstanceGroups) Insert(ctx context.Context, key *meta.Key, obj *ga.I
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEInstanceGroups.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -17765,6 +18012,7 @@ func (g *GCEInstanceGroups) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEInstanceGroups.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -17799,6 +18047,7 @@ func (g *GCEInstanceGroups) AddInstances(ctx context.Context, key *meta.Key, arg
 	call := g.s.GA.InstanceGroups.AddInstances(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEInstanceGroups.AddInstances(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -17837,6 +18086,7 @@ func (g *GCEInstanceGroups) ListInstances(ctx context.Context, key *meta.Key, ar
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEInstanceGroups.ListInstances(%v, %v, ...) = %v, %v", ctx, key, nil, err)
 		return nil, err
 	}
@@ -17876,6 +18126,7 @@ func (g *GCEInstanceGroups) RemoveInstances(ctx context.Context, key *meta.Key, 
 	call := g.s.GA.InstanceGroups.RemoveInstances(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEInstanceGroups.RemoveInstances(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -17909,6 +18160,7 @@ func (g *GCEInstanceGroups) SetNamedPorts(ctx context.Context, key *meta.Key, ar
 	call := g.s.GA.InstanceGroups.SetNamedPorts(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEInstanceGroups.SetNamedPorts(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -18160,6 +18412,7 @@ func (g *GCEInstances) Get(ctx context.Context, key *meta.Key) (*ga.Instance, er
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEInstances.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -18188,10 +18441,12 @@ func (g *GCEInstances) List(ctx context.Context, zone string, fl *filter.F) ([]*
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEInstances.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEInstances.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -18229,6 +18484,7 @@ func (g *GCEInstances) Insert(ctx context.Context, key *meta.Key, obj *ga.Instan
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEInstances.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -18262,6 +18518,7 @@ func (g *GCEInstances) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEInstances.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -18296,6 +18553,7 @@ func (g *GCEInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 *ga.A
 	call := g.s.GA.Instances.AttachDisk(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEInstances.AttachDisk(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -18329,6 +18587,7 @@ func (g *GCEInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 strin
 	call := g.s.GA.Instances.DetachDisk(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEInstances.DetachDisk(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -18590,6 +18849,7 @@ func (g *GCEBetaInstances) Get(ctx context.Context, key *meta.Key) (*beta.Instan
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaInstances.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -18618,10 +18878,12 @@ func (g *GCEBetaInstances) List(ctx context.Context, zone string, fl *filter.F) 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaInstances.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaInstances.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -18659,6 +18921,7 @@ func (g *GCEBetaInstances) Insert(ctx context.Context, key *meta.Key, obj *beta.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaInstances.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -18692,6 +18955,7 @@ func (g *GCEBetaInstances) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaInstances.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -18726,6 +18990,7 @@ func (g *GCEBetaInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 *
 	call := g.s.Beta.Instances.AttachDisk(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaInstances.AttachDisk(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -18759,6 +19024,7 @@ func (g *GCEBetaInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 s
 	call := g.s.Beta.Instances.DetachDisk(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaInstances.DetachDisk(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -18792,6 +19058,7 @@ func (g *GCEBetaInstances) UpdateNetworkInterface(ctx context.Context, key *meta
 	call := g.s.Beta.Instances.UpdateNetworkInterface(projectID, key.Zone, key.Name, arg0, arg1)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaInstances.UpdateNetworkInterface(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -19053,6 +19320,7 @@ func (g *GCEAlphaInstances) Get(ctx context.Context, key *meta.Key) (*alpha.Inst
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaInstances.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -19081,10 +19349,12 @@ func (g *GCEAlphaInstances) List(ctx context.Context, zone string, fl *filter.F)
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaInstances.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaInstances.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -19122,6 +19392,7 @@ func (g *GCEAlphaInstances) Insert(ctx context.Context, key *meta.Key, obj *alph
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaInstances.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -19155,6 +19426,7 @@ func (g *GCEAlphaInstances) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaInstances.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -19189,6 +19461,7 @@ func (g *GCEAlphaInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 
 	call := g.s.Alpha.Instances.AttachDisk(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaInstances.AttachDisk(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -19222,6 +19495,7 @@ func (g *GCEAlphaInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 
 	call := g.s.Alpha.Instances.DetachDisk(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaInstances.DetachDisk(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -19255,6 +19529,7 @@ func (g *GCEAlphaInstances) UpdateNetworkInterface(ctx context.Context, key *met
 	call := g.s.Alpha.Instances.UpdateNetworkInterface(projectID, key.Zone, key.Name, arg0, arg1)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaInstances.UpdateNetworkInterface(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -19543,6 +19818,7 @@ func (g *GCEImages) Get(ctx context.Context, key *meta.Key) (*ga.Image, error) {
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEImages.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -19571,10 +19847,12 @@ func (g *GCEImages) List(ctx context.Context, fl *filter.F) ([]*ga.Image, error)
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEImages.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEImages.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -19612,6 +19890,7 @@ func (g *GCEImages) Insert(ctx context.Context, key *meta.Key, obj *ga.Image) er
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEImages.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -19646,6 +19925,7 @@ func (g *GCEImages) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEImages.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -19680,6 +19960,7 @@ func (g *GCEImages) GetFromFamily(ctx context.Context, key *meta.Key) (*ga.Image
 	call := g.s.GA.Images.GetFromFamily(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEImages.GetFromFamily(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -19708,6 +19989,7 @@ func (g *GCEImages) GetIamPolicy(ctx context.Context, key *meta.Key) (*ga.Policy
 	call := g.s.GA.Images.GetIamPolicy(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEImages.GetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -19736,6 +20018,7 @@ func (g *GCEImages) Patch(ctx context.Context, key *meta.Key, arg0 *ga.Image) er
 	call := g.s.GA.Images.Patch(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEImages.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -19769,6 +20052,7 @@ func (g *GCEImages) SetIamPolicy(ctx context.Context, key *meta.Key, arg0 *ga.Gl
 	call := g.s.GA.Images.SetIamPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEImages.SetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -19797,6 +20081,7 @@ func (g *GCEImages) SetLabels(ctx context.Context, key *meta.Key, arg0 *ga.Globa
 	call := g.s.GA.Images.SetLabels(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEImages.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -19830,6 +20115,7 @@ func (g *GCEImages) TestIamPermissions(ctx context.Context, key *meta.Key, arg0 
 	call := g.s.GA.Images.TestIamPermissions(projectID, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEImages.TestIamPermissions(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -20113,6 +20399,7 @@ func (g *GCEBetaImages) Get(ctx context.Context, key *meta.Key) (*beta.Image, er
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaImages.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -20141,10 +20428,12 @@ func (g *GCEBetaImages) List(ctx context.Context, fl *filter.F) ([]*beta.Image, 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaImages.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaImages.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -20182,6 +20471,7 @@ func (g *GCEBetaImages) Insert(ctx context.Context, key *meta.Key, obj *beta.Ima
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaImages.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -20216,6 +20506,7 @@ func (g *GCEBetaImages) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaImages.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -20250,6 +20541,7 @@ func (g *GCEBetaImages) GetFromFamily(ctx context.Context, key *meta.Key) (*beta
 	call := g.s.Beta.Images.GetFromFamily(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBetaImages.GetFromFamily(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -20278,6 +20570,7 @@ func (g *GCEBetaImages) GetIamPolicy(ctx context.Context, key *meta.Key) (*beta.
 	call := g.s.Beta.Images.GetIamPolicy(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBetaImages.GetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -20306,6 +20599,7 @@ func (g *GCEBetaImages) Patch(ctx context.Context, key *meta.Key, arg0 *beta.Ima
 	call := g.s.Beta.Images.Patch(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaImages.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -20339,6 +20633,7 @@ func (g *GCEBetaImages) SetIamPolicy(ctx context.Context, key *meta.Key, arg0 *b
 	call := g.s.Beta.Images.SetIamPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBetaImages.SetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -20367,6 +20662,7 @@ func (g *GCEBetaImages) SetLabels(ctx context.Context, key *meta.Key, arg0 *beta
 	call := g.s.Beta.Images.SetLabels(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaImages.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -20400,6 +20696,7 @@ func (g *GCEBetaImages) TestIamPermissions(ctx context.Context, key *meta.Key, a
 	call := g.s.Beta.Images.TestIamPermissions(projectID, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBetaImages.TestIamPermissions(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -20683,6 +20980,7 @@ func (g *GCEAlphaImages) Get(ctx context.Context, key *meta.Key) (*alpha.Image, 
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaImages.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -20711,10 +21009,12 @@ func (g *GCEAlphaImages) List(ctx context.Context, fl *filter.F) ([]*alpha.Image
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaImages.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaImages.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -20752,6 +21052,7 @@ func (g *GCEAlphaImages) Insert(ctx context.Context, key *meta.Key, obj *alpha.I
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaImages.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -20786,6 +21087,7 @@ func (g *GCEAlphaImages) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaImages.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -20820,6 +21122,7 @@ func (g *GCEAlphaImages) GetFromFamily(ctx context.Context, key *meta.Key) (*alp
 	call := g.s.Alpha.Images.GetFromFamily(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaImages.GetFromFamily(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -20848,6 +21151,7 @@ func (g *GCEAlphaImages) GetIamPolicy(ctx context.Context, key *meta.Key) (*alph
 	call := g.s.Alpha.Images.GetIamPolicy(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaImages.GetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -20876,6 +21180,7 @@ func (g *GCEAlphaImages) Patch(ctx context.Context, key *meta.Key, arg0 *alpha.I
 	call := g.s.Alpha.Images.Patch(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaImages.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -20909,6 +21214,7 @@ func (g *GCEAlphaImages) SetIamPolicy(ctx context.Context, key *meta.Key, arg0 *
 	call := g.s.Alpha.Images.SetIamPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaImages.SetIamPolicy(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -20937,6 +21243,7 @@ func (g *GCEAlphaImages) SetLabels(ctx context.Context, key *meta.Key, arg0 *alp
 	call := g.s.Alpha.Images.SetLabels(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaImages.SetLabels(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -20970,6 +21277,7 @@ func (g *GCEAlphaImages) TestIamPermissions(ctx context.Context, key *meta.Key, 
 	call := g.s.Alpha.Images.TestIamPermissions(projectID, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaImages.TestIamPermissions(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -21193,6 +21501,7 @@ func (g *GCEAlphaNetworks) Get(ctx context.Context, key *meta.Key) (*alpha.Netwo
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaNetworks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -21221,10 +21530,12 @@ func (g *GCEAlphaNetworks) List(ctx context.Context, fl *filter.F) ([]*alpha.Net
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaNetworks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaNetworks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -21262,6 +21573,7 @@ func (g *GCEAlphaNetworks) Insert(ctx context.Context, key *meta.Key, obj *alpha
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -21296,6 +21608,7 @@ func (g *GCEAlphaNetworks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -21525,6 +21838,7 @@ func (g *GCEBetaNetworks) Get(ctx context.Context, key *meta.Key) (*beta.Network
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaNetworks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -21553,10 +21867,12 @@ func (g *GCEBetaNetworks) List(ctx context.Context, fl *filter.F) ([]*beta.Netwo
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaNetworks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaNetworks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -21594,6 +21910,7 @@ func (g *GCEBetaNetworks) Insert(ctx context.Context, key *meta.Key, obj *beta.N
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaNetworks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -21628,6 +21945,7 @@ func (g *GCEBetaNetworks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaNetworks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -21857,6 +22175,7 @@ func (g *GCENetworks) Get(ctx context.Context, key *meta.Key) (*ga.Network, erro
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCENetworks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -21885,10 +22204,12 @@ func (g *GCENetworks) List(ctx context.Context, fl *filter.F) ([]*ga.Network, er
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCENetworks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCENetworks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -21926,6 +22247,7 @@ func (g *GCENetworks) Insert(ctx context.Context, key *meta.Key, obj *ga.Network
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCENetworks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -21960,6 +22282,7 @@ func (g *GCENetworks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCENetworks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -22260,6 +22583,7 @@ func (g *GCEAlphaNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key) 
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaNetworkEndpointGroups.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -22288,10 +22612,12 @@ func (g *GCEAlphaNetworkEndpointGroups) List(ctx context.Context, zone string, f
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaNetworkEndpointGroups.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaNetworkEndpointGroups.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -22329,6 +22655,7 @@ func (g *GCEAlphaNetworkEndpointGroups) Insert(ctx context.Context, key *meta.Ke
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkEndpointGroups.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -22362,6 +22689,7 @@ func (g *GCEAlphaNetworkEndpointGroups) Delete(ctx context.Context, key *meta.Ke
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkEndpointGroups.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -22405,6 +22733,7 @@ func (g *GCEAlphaNetworkEndpointGroups) AggregatedList(ctx context.Context, fl *
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaNetworkEndpointGroups.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -22444,6 +22773,7 @@ func (g *GCEAlphaNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Conte
 	call := g.s.Alpha.NetworkEndpointGroups.AttachNetworkEndpoints(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -22477,6 +22807,7 @@ func (g *GCEAlphaNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Conte
 	call := g.s.Alpha.NetworkEndpointGroups.DetachNetworkEndpoints(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -22515,6 +22846,7 @@ func (g *GCEAlphaNetworkEndpointGroups) ListNetworkEndpoints(ctx context.Context
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...) = %v, %v", ctx, key, nil, err)
 		return nil, err
 	}
@@ -22820,6 +23152,7 @@ func (g *GCEBetaNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key) (
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaNetworkEndpointGroups.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -22848,10 +23181,12 @@ func (g *GCEBetaNetworkEndpointGroups) List(ctx context.Context, zone string, fl
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaNetworkEndpointGroups.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaNetworkEndpointGroups.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -22889,6 +23224,7 @@ func (g *GCEBetaNetworkEndpointGroups) Insert(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaNetworkEndpointGroups.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -22922,6 +23258,7 @@ func (g *GCEBetaNetworkEndpointGroups) Delete(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaNetworkEndpointGroups.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -22965,6 +23302,7 @@ func (g *GCEBetaNetworkEndpointGroups) AggregatedList(ctx context.Context, fl *f
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaNetworkEndpointGroups.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -23004,6 +23342,7 @@ func (g *GCEBetaNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Contex
 	call := g.s.Beta.NetworkEndpointGroups.AttachNetworkEndpoints(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -23037,6 +23376,7 @@ func (g *GCEBetaNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Contex
 	call := g.s.Beta.NetworkEndpointGroups.DetachNetworkEndpoints(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -23075,6 +23415,7 @@ func (g *GCEBetaNetworkEndpointGroups) ListNetworkEndpoints(ctx context.Context,
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...) = %v, %v", ctx, key, nil, err)
 		return nil, err
 	}
@@ -23380,6 +23721,7 @@ func (g *GCENetworkEndpointGroups) Get(ctx context.Context, key *meta.Key) (*ga.
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCENetworkEndpointGroups.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -23408,10 +23750,12 @@ func (g *GCENetworkEndpointGroups) List(ctx context.Context, zone string, fl *fi
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCENetworkEndpointGroups.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCENetworkEndpointGroups.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -23449,6 +23793,7 @@ func (g *GCENetworkEndpointGroups) Insert(ctx context.Context, key *meta.Key, ob
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCENetworkEndpointGroups.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -23482,6 +23827,7 @@ func (g *GCENetworkEndpointGroups) Delete(ctx context.Context, key *meta.Key) er
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCENetworkEndpointGroups.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -23525,6 +23871,7 @@ func (g *GCENetworkEndpointGroups) AggregatedList(ctx context.Context, fl *filte
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCENetworkEndpointGroups.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -23564,6 +23911,7 @@ func (g *GCENetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Context, k
 	call := g.s.GA.NetworkEndpointGroups.AttachNetworkEndpoints(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCENetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -23597,6 +23945,7 @@ func (g *GCENetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Context, k
 	call := g.s.GA.NetworkEndpointGroups.DetachNetworkEndpoints(projectID, key.Zone, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCENetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -23635,6 +23984,7 @@ func (g *GCENetworkEndpointGroups) ListNetworkEndpoints(ctx context.Context, key
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCENetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...) = %v, %v", ctx, key, nil, err)
 		return nil, err
 	}
@@ -23840,6 +24190,7 @@ func (g *GCERegions) Get(ctx context.Context, key *meta.Key) (*ga.Region, error)
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERegions.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -23868,10 +24219,12 @@ func (g *GCERegions) List(ctx context.Context, fl *filter.F) ([]*ga.Region, erro
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERegions.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERegions.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -24185,6 +24538,7 @@ func (g *GCEAlphaRouters) Get(ctx context.Context, key *meta.Key) (*alpha.Router
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaRouters.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -24213,10 +24567,12 @@ func (g *GCEAlphaRouters) List(ctx context.Context, region string, fl *filter.F)
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaRouters.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaRouters.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -24254,6 +24610,7 @@ func (g *GCEAlphaRouters) Insert(ctx context.Context, key *meta.Key, obj *alpha.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRouters.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -24287,6 +24644,7 @@ func (g *GCEAlphaRouters) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRouters.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -24330,6 +24688,7 @@ func (g *GCEAlphaRouters) AggregatedList(ctx context.Context, fl *filter.F) (map
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaRouters.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -24369,6 +24728,7 @@ func (g *GCEAlphaRouters) GetRouterStatus(ctx context.Context, key *meta.Key) (*
 	call := g.s.Alpha.Routers.GetRouterStatus(projectID, key.Region, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaRouters.GetRouterStatus(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -24397,6 +24757,7 @@ func (g *GCEAlphaRouters) Patch(ctx context.Context, key *meta.Key, arg0 *alpha.
 	call := g.s.Alpha.Routers.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRouters.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -24430,6 +24791,7 @@ func (g *GCEAlphaRouters) Preview(ctx context.Context, key *meta.Key, arg0 *alph
 	call := g.s.Alpha.Routers.Preview(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaRouters.Preview(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -24458,6 +24820,7 @@ func (g *GCEAlphaRouters) TestIamPermissions(ctx context.Context, key *meta.Key,
 	call := g.s.Alpha.Routers.TestIamPermissions(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEAlphaRouters.TestIamPermissions(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -24762,6 +25125,7 @@ func (g *GCEBetaRouters) Get(ctx context.Context, key *meta.Key) (*beta.Router, 
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaRouters.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -24790,10 +25154,12 @@ func (g *GCEBetaRouters) List(ctx context.Context, region string, fl *filter.F) 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaRouters.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaRouters.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -24831,6 +25197,7 @@ func (g *GCEBetaRouters) Insert(ctx context.Context, key *meta.Key, obj *beta.Ro
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRouters.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -24864,6 +25231,7 @@ func (g *GCEBetaRouters) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRouters.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -24907,6 +25275,7 @@ func (g *GCEBetaRouters) AggregatedList(ctx context.Context, fl *filter.F) (map[
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaRouters.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -24946,6 +25315,7 @@ func (g *GCEBetaRouters) GetRouterStatus(ctx context.Context, key *meta.Key) (*b
 	call := g.s.Beta.Routers.GetRouterStatus(projectID, key.Region, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBetaRouters.GetRouterStatus(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -24974,6 +25344,7 @@ func (g *GCEBetaRouters) Patch(ctx context.Context, key *meta.Key, arg0 *beta.Ro
 	call := g.s.Beta.Routers.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRouters.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -25007,6 +25378,7 @@ func (g *GCEBetaRouters) Preview(ctx context.Context, key *meta.Key, arg0 *beta.
 	call := g.s.Beta.Routers.Preview(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBetaRouters.Preview(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -25035,6 +25407,7 @@ func (g *GCEBetaRouters) TestIamPermissions(ctx context.Context, key *meta.Key, 
 	call := g.s.Beta.Routers.TestIamPermissions(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBetaRouters.TestIamPermissions(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -25329,6 +25702,7 @@ func (g *GCERouters) Get(ctx context.Context, key *meta.Key) (*ga.Router, error)
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERouters.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -25357,10 +25731,12 @@ func (g *GCERouters) List(ctx context.Context, region string, fl *filter.F) ([]*
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERouters.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERouters.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -25398,6 +25774,7 @@ func (g *GCERouters) Insert(ctx context.Context, key *meta.Key, obj *ga.Router) 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERouters.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -25431,6 +25808,7 @@ func (g *GCERouters) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERouters.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -25474,6 +25852,7 @@ func (g *GCERouters) AggregatedList(ctx context.Context, fl *filter.F) (map[stri
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERouters.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -25513,6 +25892,7 @@ func (g *GCERouters) GetRouterStatus(ctx context.Context, key *meta.Key) (*ga.Ro
 	call := g.s.GA.Routers.GetRouterStatus(projectID, key.Region, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCERouters.GetRouterStatus(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -25541,6 +25921,7 @@ func (g *GCERouters) Patch(ctx context.Context, key *meta.Key, arg0 *ga.Router) 
 	call := g.s.GA.Routers.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERouters.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -25574,6 +25955,7 @@ func (g *GCERouters) Preview(ctx context.Context, key *meta.Key, arg0 *ga.Router
 	call := g.s.GA.Routers.Preview(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCERouters.Preview(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -25797,6 +26179,7 @@ func (g *GCERoutes) Get(ctx context.Context, key *meta.Key) (*ga.Route, error) {
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERoutes.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -25825,10 +26208,12 @@ func (g *GCERoutes) List(ctx context.Context, fl *filter.F) ([]*ga.Route, error)
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERoutes.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERoutes.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -25866,6 +26251,7 @@ func (g *GCERoutes) Insert(ctx context.Context, key *meta.Key, obj *ga.Route) er
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERoutes.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -25900,6 +26286,7 @@ func (g *GCERoutes) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERoutes.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -26179,6 +26566,7 @@ func (g *GCEBetaSecurityPolicies) Get(ctx context.Context, key *meta.Key) (*beta
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaSecurityPolicies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -26207,10 +26595,12 @@ func (g *GCEBetaSecurityPolicies) List(ctx context.Context, fl *filter.F) ([]*be
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaSecurityPolicies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaSecurityPolicies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -26248,6 +26638,7 @@ func (g *GCEBetaSecurityPolicies) Insert(ctx context.Context, key *meta.Key, obj
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSecurityPolicies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -26282,6 +26673,7 @@ func (g *GCEBetaSecurityPolicies) Delete(ctx context.Context, key *meta.Key) err
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSecurityPolicies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -26316,6 +26708,7 @@ func (g *GCEBetaSecurityPolicies) AddRule(ctx context.Context, key *meta.Key, ar
 	call := g.s.Beta.SecurityPolicies.AddRule(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSecurityPolicies.AddRule(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -26349,6 +26742,7 @@ func (g *GCEBetaSecurityPolicies) GetRule(ctx context.Context, key *meta.Key) (*
 	call := g.s.Beta.SecurityPolicies.GetRule(projectID, key.Name)
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("GCEBetaSecurityPolicies.GetRule(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 }
@@ -26377,6 +26771,7 @@ func (g *GCEBetaSecurityPolicies) Patch(ctx context.Context, key *meta.Key, arg0
 	call := g.s.Beta.SecurityPolicies.Patch(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSecurityPolicies.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -26410,6 +26805,7 @@ func (g *GCEBetaSecurityPolicies) PatchRule(ctx context.Context, key *meta.Key, 
 	call := g.s.Beta.SecurityPolicies.PatchRule(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSecurityPolicies.PatchRule(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -26443,6 +26839,7 @@ func (g *GCEBetaSecurityPolicies) RemoveRule(ctx context.Context, key *meta.Key)
 	call := g.s.Beta.SecurityPolicies.RemoveRule(projectID, key.Name)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSecurityPolicies.RemoveRule(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -26684,6 +27081,7 @@ func (g *GCEServiceAttachments) Get(ctx context.Context, key *meta.Key) (*ga.Ser
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEServiceAttachments.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -26712,10 +27110,12 @@ func (g *GCEServiceAttachments) List(ctx context.Context, region string, fl *fil
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEServiceAttachments.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEServiceAttachments.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -26753,6 +27153,7 @@ func (g *GCEServiceAttachments) Insert(ctx context.Context, key *meta.Key, obj *
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEServiceAttachments.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -26786,6 +27187,7 @@ func (g *GCEServiceAttachments) Delete(ctx context.Context, key *meta.Key) error
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEServiceAttachments.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -26820,6 +27222,7 @@ func (g *GCEServiceAttachments) Patch(ctx context.Context, key *meta.Key, arg0 *
 	call := g.s.GA.ServiceAttachments.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEServiceAttachments.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -27061,6 +27464,7 @@ func (g *GCEBetaServiceAttachments) Get(ctx context.Context, key *meta.Key) (*be
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaServiceAttachments.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -27089,10 +27493,12 @@ func (g *GCEBetaServiceAttachments) List(ctx context.Context, region string, fl 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaServiceAttachments.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaServiceAttachments.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -27130,6 +27536,7 @@ func (g *GCEBetaServiceAttachments) Insert(ctx context.Context, key *meta.Key, o
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaServiceAttachments.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -27163,6 +27570,7 @@ func (g *GCEBetaServiceAttachments) Delete(ctx context.Context, key *meta.Key) e
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaServiceAttachments.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -27197,6 +27605,7 @@ func (g *GCEBetaServiceAttachments) Patch(ctx context.Context, key *meta.Key, ar
 	call := g.s.Beta.ServiceAttachments.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaServiceAttachments.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -27438,6 +27847,7 @@ func (g *GCEAlphaServiceAttachments) Get(ctx context.Context, key *meta.Key) (*a
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaServiceAttachments.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -27466,10 +27876,12 @@ func (g *GCEAlphaServiceAttachments) List(ctx context.Context, region string, fl
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaServiceAttachments.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaServiceAttachments.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -27507,6 +27919,7 @@ func (g *GCEAlphaServiceAttachments) Insert(ctx context.Context, key *meta.Key, 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaServiceAttachments.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -27540,6 +27953,7 @@ func (g *GCEAlphaServiceAttachments) Delete(ctx context.Context, key *meta.Key) 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaServiceAttachments.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -27574,6 +27988,7 @@ func (g *GCEAlphaServiceAttachments) Patch(ctx context.Context, key *meta.Key, a
 	call := g.s.Alpha.ServiceAttachments.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaServiceAttachments.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -27802,6 +28217,7 @@ func (g *GCESslCertificates) Get(ctx context.Context, key *meta.Key) (*ga.SslCer
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCESslCertificates.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -27830,10 +28246,12 @@ func (g *GCESslCertificates) List(ctx context.Context, fl *filter.F) ([]*ga.SslC
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCESslCertificates.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCESslCertificates.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -27871,6 +28289,7 @@ func (g *GCESslCertificates) Insert(ctx context.Context, key *meta.Key, obj *ga.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCESslCertificates.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -27905,6 +28324,7 @@ func (g *GCESslCertificates) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCESslCertificates.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -28134,6 +28554,7 @@ func (g *GCEBetaSslCertificates) Get(ctx context.Context, key *meta.Key) (*beta.
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaSslCertificates.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -28162,10 +28583,12 @@ func (g *GCEBetaSslCertificates) List(ctx context.Context, fl *filter.F) ([]*bet
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaSslCertificates.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaSslCertificates.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -28203,6 +28626,7 @@ func (g *GCEBetaSslCertificates) Insert(ctx context.Context, key *meta.Key, obj 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSslCertificates.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -28237,6 +28661,7 @@ func (g *GCEBetaSslCertificates) Delete(ctx context.Context, key *meta.Key) erro
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSslCertificates.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -28466,6 +28891,7 @@ func (g *GCEAlphaSslCertificates) Get(ctx context.Context, key *meta.Key) (*alph
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaSslCertificates.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -28494,10 +28920,12 @@ func (g *GCEAlphaSslCertificates) List(ctx context.Context, fl *filter.F) ([]*al
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaSslCertificates.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaSslCertificates.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -28535,6 +28963,7 @@ func (g *GCEAlphaSslCertificates) Insert(ctx context.Context, key *meta.Key, obj
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaSslCertificates.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -28569,6 +28998,7 @@ func (g *GCEAlphaSslCertificates) Delete(ctx context.Context, key *meta.Key) err
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaSslCertificates.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -28801,6 +29231,7 @@ func (g *GCEAlphaRegionSslCertificates) Get(ctx context.Context, key *meta.Key) 
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaRegionSslCertificates.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -28829,10 +29260,12 @@ func (g *GCEAlphaRegionSslCertificates) List(ctx context.Context, region string,
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaRegionSslCertificates.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaRegionSslCertificates.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -28870,6 +29303,7 @@ func (g *GCEAlphaRegionSslCertificates) Insert(ctx context.Context, key *meta.Ke
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionSslCertificates.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -28903,6 +29337,7 @@ func (g *GCEAlphaRegionSslCertificates) Delete(ctx context.Context, key *meta.Ke
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionSslCertificates.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -29135,6 +29570,7 @@ func (g *GCEBetaRegionSslCertificates) Get(ctx context.Context, key *meta.Key) (
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaRegionSslCertificates.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -29163,10 +29599,12 @@ func (g *GCEBetaRegionSslCertificates) List(ctx context.Context, region string, 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaRegionSslCertificates.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaRegionSslCertificates.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -29204,6 +29642,7 @@ func (g *GCEBetaRegionSslCertificates) Insert(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionSslCertificates.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -29237,6 +29676,7 @@ func (g *GCEBetaRegionSslCertificates) Delete(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionSslCertificates.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -29469,6 +29909,7 @@ func (g *GCERegionSslCertificates) Get(ctx context.Context, key *meta.Key) (*ga.
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERegionSslCertificates.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -29497,10 +29938,12 @@ func (g *GCERegionSslCertificates) List(ctx context.Context, region string, fl *
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERegionSslCertificates.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERegionSslCertificates.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -29538,6 +29981,7 @@ func (g *GCERegionSslCertificates) Insert(ctx context.Context, key *meta.Key, ob
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionSslCertificates.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -29571,6 +30015,7 @@ func (g *GCERegionSslCertificates) Delete(ctx context.Context, key *meta.Key) er
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionSslCertificates.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -29766,6 +30211,7 @@ func (g *GCESslPolicies) Get(ctx context.Context, key *meta.Key) (*ga.SslPolicy,
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCESslPolicies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -29793,6 +30239,7 @@ func (g *GCESslPolicies) Insert(ctx context.Context, key *meta.Key, obj *ga.SslP
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCESslPolicies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -29827,6 +30274,7 @@ func (g *GCESslPolicies) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCESslPolicies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -30108,6 +30556,7 @@ func (g *GCEAlphaSubnetworks) Get(ctx context.Context, key *meta.Key) (*alpha.Su
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaSubnetworks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -30136,10 +30585,12 @@ func (g *GCEAlphaSubnetworks) List(ctx context.Context, region string, fl *filte
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaSubnetworks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaSubnetworks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -30177,6 +30628,7 @@ func (g *GCEAlphaSubnetworks) Insert(ctx context.Context, key *meta.Key, obj *al
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaSubnetworks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -30210,6 +30662,7 @@ func (g *GCEAlphaSubnetworks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaSubnetworks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -30245,6 +30698,7 @@ func (g *GCEAlphaSubnetworks) ListUsable(ctx context.Context, fl *filter.F) ([]*
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaSubnetworks.ListUsable(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -30286,6 +30740,7 @@ func (g *GCEAlphaSubnetworks) Patch(ctx context.Context, key *meta.Key, arg0 *al
 	call := g.s.Alpha.Subnetworks.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaSubnetworks.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -30566,6 +31021,7 @@ func (g *GCEBetaSubnetworks) Get(ctx context.Context, key *meta.Key) (*beta.Subn
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaSubnetworks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -30594,10 +31050,12 @@ func (g *GCEBetaSubnetworks) List(ctx context.Context, region string, fl *filter
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaSubnetworks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaSubnetworks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -30635,6 +31093,7 @@ func (g *GCEBetaSubnetworks) Insert(ctx context.Context, key *meta.Key, obj *bet
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSubnetworks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -30668,6 +31127,7 @@ func (g *GCEBetaSubnetworks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSubnetworks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -30703,6 +31163,7 @@ func (g *GCEBetaSubnetworks) ListUsable(ctx context.Context, fl *filter.F) ([]*b
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaSubnetworks.ListUsable(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -30744,6 +31205,7 @@ func (g *GCEBetaSubnetworks) Patch(ctx context.Context, key *meta.Key, arg0 *bet
 	call := g.s.Beta.Subnetworks.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaSubnetworks.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -31024,6 +31486,7 @@ func (g *GCESubnetworks) Get(ctx context.Context, key *meta.Key) (*ga.Subnetwork
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCESubnetworks.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -31052,10 +31515,12 @@ func (g *GCESubnetworks) List(ctx context.Context, region string, fl *filter.F) 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCESubnetworks.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCESubnetworks.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -31093,6 +31558,7 @@ func (g *GCESubnetworks) Insert(ctx context.Context, key *meta.Key, obj *ga.Subn
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCESubnetworks.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -31126,6 +31592,7 @@ func (g *GCESubnetworks) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCESubnetworks.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -31161,6 +31628,7 @@ func (g *GCESubnetworks) ListUsable(ctx context.Context, fl *filter.F) ([]*ga.Us
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCESubnetworks.ListUsable(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -31202,6 +31670,7 @@ func (g *GCESubnetworks) Patch(ctx context.Context, key *meta.Key, arg0 *ga.Subn
 	call := g.s.GA.Subnetworks.Patch(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCESubnetworks.Patch(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -31440,6 +31909,7 @@ func (g *GCEAlphaTargetHttpProxies) Get(ctx context.Context, key *meta.Key) (*al
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaTargetHttpProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -31468,10 +31938,12 @@ func (g *GCEAlphaTargetHttpProxies) List(ctx context.Context, fl *filter.F) ([]*
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaTargetHttpProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaTargetHttpProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -31509,6 +31981,7 @@ func (g *GCEAlphaTargetHttpProxies) Insert(ctx context.Context, key *meta.Key, o
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetHttpProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -31543,6 +32016,7 @@ func (g *GCEAlphaTargetHttpProxies) Delete(ctx context.Context, key *meta.Key) e
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetHttpProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -31577,6 +32051,7 @@ func (g *GCEAlphaTargetHttpProxies) SetUrlMap(ctx context.Context, key *meta.Key
 	call := g.s.Alpha.TargetHttpProxies.SetUrlMap(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetHttpProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -31815,6 +32290,7 @@ func (g *GCEBetaTargetHttpProxies) Get(ctx context.Context, key *meta.Key) (*bet
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaTargetHttpProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -31843,10 +32319,12 @@ func (g *GCEBetaTargetHttpProxies) List(ctx context.Context, fl *filter.F) ([]*b
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaTargetHttpProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaTargetHttpProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -31884,6 +32362,7 @@ func (g *GCEBetaTargetHttpProxies) Insert(ctx context.Context, key *meta.Key, ob
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetHttpProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -31918,6 +32397,7 @@ func (g *GCEBetaTargetHttpProxies) Delete(ctx context.Context, key *meta.Key) er
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetHttpProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -31952,6 +32432,7 @@ func (g *GCEBetaTargetHttpProxies) SetUrlMap(ctx context.Context, key *meta.Key,
 	call := g.s.Beta.TargetHttpProxies.SetUrlMap(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetHttpProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -32190,6 +32671,7 @@ func (g *GCETargetHttpProxies) Get(ctx context.Context, key *meta.Key) (*ga.Targ
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCETargetHttpProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -32218,10 +32700,12 @@ func (g *GCETargetHttpProxies) List(ctx context.Context, fl *filter.F) ([]*ga.Ta
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCETargetHttpProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCETargetHttpProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -32259,6 +32743,7 @@ func (g *GCETargetHttpProxies) Insert(ctx context.Context, key *meta.Key, obj *g
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetHttpProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -32293,6 +32778,7 @@ func (g *GCETargetHttpProxies) Delete(ctx context.Context, key *meta.Key) error 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetHttpProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -32327,6 +32813,7 @@ func (g *GCETargetHttpProxies) SetUrlMap(ctx context.Context, key *meta.Key, arg
 	call := g.s.GA.TargetHttpProxies.SetUrlMap(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetHttpProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -32568,6 +33055,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) Get(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaRegionTargetHttpProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -32596,10 +33084,12 @@ func (g *GCEAlphaRegionTargetHttpProxies) List(ctx context.Context, region strin
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -32637,6 +33127,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) Insert(ctx context.Context, key *meta.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -32670,6 +33161,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) Delete(ctx context.Context, key *meta.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -32704,6 +33196,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) SetUrlMap(ctx context.Context, key *me
 	call := g.s.Alpha.RegionTargetHttpProxies.SetUrlMap(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -32945,6 +33438,7 @@ func (g *GCEBetaRegionTargetHttpProxies) Get(ctx context.Context, key *meta.Key)
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaRegionTargetHttpProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -32973,10 +33467,12 @@ func (g *GCEBetaRegionTargetHttpProxies) List(ctx context.Context, region string
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaRegionTargetHttpProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaRegionTargetHttpProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -33014,6 +33510,7 @@ func (g *GCEBetaRegionTargetHttpProxies) Insert(ctx context.Context, key *meta.K
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionTargetHttpProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -33047,6 +33544,7 @@ func (g *GCEBetaRegionTargetHttpProxies) Delete(ctx context.Context, key *meta.K
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionTargetHttpProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -33081,6 +33579,7 @@ func (g *GCEBetaRegionTargetHttpProxies) SetUrlMap(ctx context.Context, key *met
 	call := g.s.Beta.RegionTargetHttpProxies.SetUrlMap(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionTargetHttpProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -33322,6 +33821,7 @@ func (g *GCERegionTargetHttpProxies) Get(ctx context.Context, key *meta.Key) (*g
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERegionTargetHttpProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -33350,10 +33850,12 @@ func (g *GCERegionTargetHttpProxies) List(ctx context.Context, region string, fl
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERegionTargetHttpProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERegionTargetHttpProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -33391,6 +33893,7 @@ func (g *GCERegionTargetHttpProxies) Insert(ctx context.Context, key *meta.Key, 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionTargetHttpProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -33424,6 +33927,7 @@ func (g *GCERegionTargetHttpProxies) Delete(ctx context.Context, key *meta.Key) 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionTargetHttpProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -33458,6 +33962,7 @@ func (g *GCERegionTargetHttpProxies) SetUrlMap(ctx context.Context, key *meta.Ke
 	call := g.s.GA.RegionTargetHttpProxies.SetUrlMap(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionTargetHttpProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -33726,6 +34231,7 @@ func (g *GCETargetHttpsProxies) Get(ctx context.Context, key *meta.Key) (*ga.Tar
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCETargetHttpsProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -33754,10 +34260,12 @@ func (g *GCETargetHttpsProxies) List(ctx context.Context, fl *filter.F) ([]*ga.T
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCETargetHttpsProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCETargetHttpsProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -33795,6 +34303,7 @@ func (g *GCETargetHttpsProxies) Insert(ctx context.Context, key *meta.Key, obj *
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetHttpsProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -33829,6 +34338,7 @@ func (g *GCETargetHttpsProxies) Delete(ctx context.Context, key *meta.Key) error
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetHttpsProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -33863,6 +34373,7 @@ func (g *GCETargetHttpsProxies) SetCertificateMap(ctx context.Context, key *meta
 	call := g.s.GA.TargetHttpsProxies.SetCertificateMap(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetHttpsProxies.SetCertificateMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -33896,6 +34407,7 @@ func (g *GCETargetHttpsProxies) SetSslCertificates(ctx context.Context, key *met
 	call := g.s.GA.TargetHttpsProxies.SetSslCertificates(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetHttpsProxies.SetSslCertificates(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -33929,6 +34441,7 @@ func (g *GCETargetHttpsProxies) SetSslPolicy(ctx context.Context, key *meta.Key,
 	call := g.s.GA.TargetHttpsProxies.SetSslPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetHttpsProxies.SetSslPolicy(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -33962,6 +34475,7 @@ func (g *GCETargetHttpsProxies) SetUrlMap(ctx context.Context, key *meta.Key, ar
 	call := g.s.GA.TargetHttpsProxies.SetUrlMap(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetHttpsProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34230,6 +34744,7 @@ func (g *GCEAlphaTargetHttpsProxies) Get(ctx context.Context, key *meta.Key) (*a
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaTargetHttpsProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -34258,10 +34773,12 @@ func (g *GCEAlphaTargetHttpsProxies) List(ctx context.Context, fl *filter.F) ([]
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaTargetHttpsProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaTargetHttpsProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -34299,6 +34816,7 @@ func (g *GCEAlphaTargetHttpsProxies) Insert(ctx context.Context, key *meta.Key, 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetHttpsProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34333,6 +34851,7 @@ func (g *GCEAlphaTargetHttpsProxies) Delete(ctx context.Context, key *meta.Key) 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetHttpsProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -34367,6 +34886,7 @@ func (g *GCEAlphaTargetHttpsProxies) SetCertificateMap(ctx context.Context, key 
 	call := g.s.Alpha.TargetHttpsProxies.SetCertificateMap(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetHttpsProxies.SetCertificateMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34400,6 +34920,7 @@ func (g *GCEAlphaTargetHttpsProxies) SetSslCertificates(ctx context.Context, key
 	call := g.s.Alpha.TargetHttpsProxies.SetSslCertificates(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetHttpsProxies.SetSslCertificates(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34433,6 +34954,7 @@ func (g *GCEAlphaTargetHttpsProxies) SetSslPolicy(ctx context.Context, key *meta
 	call := g.s.Alpha.TargetHttpsProxies.SetSslPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetHttpsProxies.SetSslPolicy(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34466,6 +34988,7 @@ func (g *GCEAlphaTargetHttpsProxies) SetUrlMap(ctx context.Context, key *meta.Ke
 	call := g.s.Alpha.TargetHttpsProxies.SetUrlMap(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetHttpsProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34734,6 +35257,7 @@ func (g *GCEBetaTargetHttpsProxies) Get(ctx context.Context, key *meta.Key) (*be
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaTargetHttpsProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -34762,10 +35286,12 @@ func (g *GCEBetaTargetHttpsProxies) List(ctx context.Context, fl *filter.F) ([]*
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaTargetHttpsProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaTargetHttpsProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -34803,6 +35329,7 @@ func (g *GCEBetaTargetHttpsProxies) Insert(ctx context.Context, key *meta.Key, o
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetHttpsProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34837,6 +35364,7 @@ func (g *GCEBetaTargetHttpsProxies) Delete(ctx context.Context, key *meta.Key) e
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetHttpsProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -34871,6 +35399,7 @@ func (g *GCEBetaTargetHttpsProxies) SetCertificateMap(ctx context.Context, key *
 	call := g.s.Beta.TargetHttpsProxies.SetCertificateMap(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetHttpsProxies.SetCertificateMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34904,6 +35433,7 @@ func (g *GCEBetaTargetHttpsProxies) SetSslCertificates(ctx context.Context, key 
 	call := g.s.Beta.TargetHttpsProxies.SetSslCertificates(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetHttpsProxies.SetSslCertificates(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34937,6 +35467,7 @@ func (g *GCEBetaTargetHttpsProxies) SetSslPolicy(ctx context.Context, key *meta.
 	call := g.s.Beta.TargetHttpsProxies.SetSslPolicy(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetHttpsProxies.SetSslPolicy(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -34970,6 +35501,7 @@ func (g *GCEBetaTargetHttpsProxies) SetUrlMap(ctx context.Context, key *meta.Key
 	call := g.s.Beta.TargetHttpsProxies.SetUrlMap(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetHttpsProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -35221,6 +35753,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) Get(ctx context.Context, key *meta.Ke
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaRegionTargetHttpsProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -35249,10 +35782,12 @@ func (g *GCEAlphaRegionTargetHttpsProxies) List(ctx context.Context, region stri
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpsProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpsProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -35290,6 +35825,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) Insert(ctx context.Context, key *meta
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpsProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -35323,6 +35859,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) Delete(ctx context.Context, key *meta
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpsProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -35357,6 +35894,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) SetSslCertificates(ctx context.Contex
 	call := g.s.Alpha.RegionTargetHttpsProxies.SetSslCertificates(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpsProxies.SetSslCertificates(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -35390,6 +35928,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) SetUrlMap(ctx context.Context, key *m
 	call := g.s.Alpha.RegionTargetHttpsProxies.SetUrlMap(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionTargetHttpsProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -35641,6 +36180,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) Get(ctx context.Context, key *meta.Key
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaRegionTargetHttpsProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -35669,10 +36209,12 @@ func (g *GCEBetaRegionTargetHttpsProxies) List(ctx context.Context, region strin
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaRegionTargetHttpsProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaRegionTargetHttpsProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -35710,6 +36252,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) Insert(ctx context.Context, key *meta.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionTargetHttpsProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -35743,6 +36286,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) Delete(ctx context.Context, key *meta.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionTargetHttpsProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -35777,6 +36321,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) SetSslCertificates(ctx context.Context
 	call := g.s.Beta.RegionTargetHttpsProxies.SetSslCertificates(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionTargetHttpsProxies.SetSslCertificates(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -35810,6 +36355,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) SetUrlMap(ctx context.Context, key *me
 	call := g.s.Beta.RegionTargetHttpsProxies.SetUrlMap(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionTargetHttpsProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -36061,6 +36607,7 @@ func (g *GCERegionTargetHttpsProxies) Get(ctx context.Context, key *meta.Key) (*
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERegionTargetHttpsProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -36089,10 +36636,12 @@ func (g *GCERegionTargetHttpsProxies) List(ctx context.Context, region string, f
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERegionTargetHttpsProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERegionTargetHttpsProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -36130,6 +36679,7 @@ func (g *GCERegionTargetHttpsProxies) Insert(ctx context.Context, key *meta.Key,
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionTargetHttpsProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -36163,6 +36713,7 @@ func (g *GCERegionTargetHttpsProxies) Delete(ctx context.Context, key *meta.Key)
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionTargetHttpsProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -36197,6 +36748,7 @@ func (g *GCERegionTargetHttpsProxies) SetSslCertificates(ctx context.Context, ke
 	call := g.s.GA.RegionTargetHttpsProxies.SetSslCertificates(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionTargetHttpsProxies.SetSslCertificates(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -36230,6 +36782,7 @@ func (g *GCERegionTargetHttpsProxies) SetUrlMap(ctx context.Context, key *meta.K
 	call := g.s.GA.RegionTargetHttpsProxies.SetUrlMap(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionTargetHttpsProxies.SetUrlMap(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -36481,6 +37034,7 @@ func (g *GCETargetPools) Get(ctx context.Context, key *meta.Key) (*ga.TargetPool
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCETargetPools.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -36509,10 +37063,12 @@ func (g *GCETargetPools) List(ctx context.Context, region string, fl *filter.F) 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCETargetPools.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCETargetPools.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -36550,6 +37106,7 @@ func (g *GCETargetPools) Insert(ctx context.Context, key *meta.Key, obj *ga.Targ
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetPools.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -36583,6 +37140,7 @@ func (g *GCETargetPools) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetPools.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -36617,6 +37175,7 @@ func (g *GCETargetPools) AddInstance(ctx context.Context, key *meta.Key, arg0 *g
 	call := g.s.GA.TargetPools.AddInstance(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetPools.AddInstance(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -36650,6 +37209,7 @@ func (g *GCETargetPools) RemoveInstance(ctx context.Context, key *meta.Key, arg0
 	call := g.s.GA.TargetPools.RemoveInstance(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetPools.RemoveInstance(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -36888,6 +37448,7 @@ func (g *GCEAlphaTargetTcpProxies) Get(ctx context.Context, key *meta.Key) (*alp
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaTargetTcpProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -36916,10 +37477,12 @@ func (g *GCEAlphaTargetTcpProxies) List(ctx context.Context, fl *filter.F) ([]*a
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaTargetTcpProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaTargetTcpProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -36957,6 +37520,7 @@ func (g *GCEAlphaTargetTcpProxies) Insert(ctx context.Context, key *meta.Key, ob
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetTcpProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -36991,6 +37555,7 @@ func (g *GCEAlphaTargetTcpProxies) Delete(ctx context.Context, key *meta.Key) er
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetTcpProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -37025,6 +37590,7 @@ func (g *GCEAlphaTargetTcpProxies) SetBackendService(ctx context.Context, key *m
 	call := g.s.Alpha.TargetTcpProxies.SetBackendService(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaTargetTcpProxies.SetBackendService(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -37263,6 +37829,7 @@ func (g *GCEBetaTargetTcpProxies) Get(ctx context.Context, key *meta.Key) (*beta
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaTargetTcpProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -37291,10 +37858,12 @@ func (g *GCEBetaTargetTcpProxies) List(ctx context.Context, fl *filter.F) ([]*be
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaTargetTcpProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaTargetTcpProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -37332,6 +37901,7 @@ func (g *GCEBetaTargetTcpProxies) Insert(ctx context.Context, key *meta.Key, obj
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetTcpProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -37366,6 +37936,7 @@ func (g *GCEBetaTargetTcpProxies) Delete(ctx context.Context, key *meta.Key) err
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetTcpProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -37400,6 +37971,7 @@ func (g *GCEBetaTargetTcpProxies) SetBackendService(ctx context.Context, key *me
 	call := g.s.Beta.TargetTcpProxies.SetBackendService(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaTargetTcpProxies.SetBackendService(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -37638,6 +38210,7 @@ func (g *GCETargetTcpProxies) Get(ctx context.Context, key *meta.Key) (*ga.Targe
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCETargetTcpProxies.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -37666,10 +38239,12 @@ func (g *GCETargetTcpProxies) List(ctx context.Context, fl *filter.F) ([]*ga.Tar
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCETargetTcpProxies.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCETargetTcpProxies.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -37707,6 +38282,7 @@ func (g *GCETargetTcpProxies) Insert(ctx context.Context, key *meta.Key, obj *ga
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetTcpProxies.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -37741,6 +38317,7 @@ func (g *GCETargetTcpProxies) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetTcpProxies.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -37775,6 +38352,7 @@ func (g *GCETargetTcpProxies) SetBackendService(ctx context.Context, key *meta.K
 	call := g.s.GA.TargetTcpProxies.SetBackendService(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCETargetTcpProxies.SetBackendService(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -38013,6 +38591,7 @@ func (g *GCEAlphaUrlMaps) Get(ctx context.Context, key *meta.Key) (*alpha.UrlMap
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaUrlMaps.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -38041,10 +38620,12 @@ func (g *GCEAlphaUrlMaps) List(ctx context.Context, fl *filter.F) ([]*alpha.UrlM
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaUrlMaps.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaUrlMaps.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -38082,6 +38663,7 @@ func (g *GCEAlphaUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *alpha.
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaUrlMaps.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -38116,6 +38698,7 @@ func (g *GCEAlphaUrlMaps) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaUrlMaps.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -38150,6 +38733,7 @@ func (g *GCEAlphaUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *alpha
 	call := g.s.Alpha.UrlMaps.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaUrlMaps.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -38388,6 +38972,7 @@ func (g *GCEBetaUrlMaps) Get(ctx context.Context, key *meta.Key) (*beta.UrlMap, 
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaUrlMaps.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -38416,10 +39001,12 @@ func (g *GCEBetaUrlMaps) List(ctx context.Context, fl *filter.F) ([]*beta.UrlMap
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaUrlMaps.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaUrlMaps.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -38457,6 +39044,7 @@ func (g *GCEBetaUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *beta.Ur
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaUrlMaps.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -38491,6 +39079,7 @@ func (g *GCEBetaUrlMaps) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaUrlMaps.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -38525,6 +39114,7 @@ func (g *GCEBetaUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *beta.U
 	call := g.s.Beta.UrlMaps.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaUrlMaps.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -38763,6 +39353,7 @@ func (g *GCEUrlMaps) Get(ctx context.Context, key *meta.Key) (*ga.UrlMap, error)
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEUrlMaps.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -38791,10 +39382,12 @@ func (g *GCEUrlMaps) List(ctx context.Context, fl *filter.F) ([]*ga.UrlMap, erro
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEUrlMaps.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEUrlMaps.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -38832,6 +39425,7 @@ func (g *GCEUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *ga.UrlMap) 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEUrlMaps.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -38866,6 +39460,7 @@ func (g *GCEUrlMaps) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEUrlMaps.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -38900,6 +39495,7 @@ func (g *GCEUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *ga.UrlMap)
 	call := g.s.GA.UrlMaps.Update(projectID, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEUrlMaps.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -39141,6 +39737,7 @@ func (g *GCEAlphaRegionUrlMaps) Get(ctx context.Context, key *meta.Key) (*alpha.
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEAlphaRegionUrlMaps.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -39169,10 +39766,12 @@ func (g *GCEAlphaRegionUrlMaps) List(ctx context.Context, region string, fl *fil
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEAlphaRegionUrlMaps.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEAlphaRegionUrlMaps.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -39210,6 +39809,7 @@ func (g *GCEAlphaRegionUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionUrlMaps.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -39243,6 +39843,7 @@ func (g *GCEAlphaRegionUrlMaps) Delete(ctx context.Context, key *meta.Key) error
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionUrlMaps.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -39277,6 +39878,7 @@ func (g *GCEAlphaRegionUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 
 	call := g.s.Alpha.RegionUrlMaps.Update(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEAlphaRegionUrlMaps.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -39518,6 +40120,7 @@ func (g *GCEBetaRegionUrlMaps) Get(ctx context.Context, key *meta.Key) (*beta.Ur
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEBetaRegionUrlMaps.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -39546,10 +40149,12 @@ func (g *GCEBetaRegionUrlMaps) List(ctx context.Context, region string, fl *filt
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEBetaRegionUrlMaps.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEBetaRegionUrlMaps.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -39587,6 +40192,7 @@ func (g *GCEBetaRegionUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *b
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionUrlMaps.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -39620,6 +40226,7 @@ func (g *GCEBetaRegionUrlMaps) Delete(ctx context.Context, key *meta.Key) error 
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionUrlMaps.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -39654,6 +40261,7 @@ func (g *GCEBetaRegionUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *
 	call := g.s.Beta.RegionUrlMaps.Update(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCEBetaRegionUrlMaps.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -39895,6 +40503,7 @@ func (g *GCERegionUrlMaps) Get(ctx context.Context, key *meta.Key) (*ga.UrlMap, 
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCERegionUrlMaps.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -39923,10 +40532,12 @@ func (g *GCERegionUrlMaps) List(ctx context.Context, region string, fl *filter.F
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCERegionUrlMaps.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCERegionUrlMaps.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -39964,6 +40575,7 @@ func (g *GCERegionUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *ga.Ur
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionUrlMaps.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -39997,6 +40609,7 @@ func (g *GCERegionUrlMaps) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionUrlMaps.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -40031,6 +40644,7 @@ func (g *GCERegionUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *ga.U
 	call := g.s.GA.RegionUrlMaps.Update(projectID, key.Region, key.Name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("GCERegionUrlMaps.Update(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -40181,6 +40795,7 @@ func (g *GCEZones) Get(ctx context.Context, key *meta.Key) (*ga.Zone, error) {
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("GCEZones.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 
@@ -40209,10 +40824,12 @@ func (g *GCEZones) List(ctx context.Context, fl *filter.F) ([]*ga.Zone, error) {
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("GCEZones.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("GCEZones.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {

--- a/pkg/cloud/gen/main.go
+++ b/pkg/cloud/gen/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Generator for GCE compute wrapper code. You must regenerate the code after
 // modifying this file:
 //
-//   $ go run gen/main.go > gen.go
+//	$ go run gen/main.go > gen.go
 package main
 
 import (
@@ -731,6 +731,7 @@ func (g *{{.GCEWrapType}}) Get(ctx context.Context, key *meta.Key) (*{{.FQObject
 	call.Context(ctx)
 	v, err := call.Do()
 	klog.V(4).Infof("{{.GCEWrapType}}.Get(%v, %v) = %+v, %v", ctx, key, v, err)
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	return v, err
 }
 {{- end}}
@@ -781,10 +782,12 @@ func (g *{{.GCEWrapType}}) List(ctx context.Context, zone string, fl *filter.F) 
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("{{.GCEWrapType}}.List(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
 
+	g.s.RateLimiter.Observe(ctx, nil, rk)
 	if klog.V(4).Enabled() {
 		klog.V(4).Infof("{{.GCEWrapType}}.List(%v, ..., %v) = [%v items], %v", ctx, fl, len(all), nil)
 	} else if klog.V(5).Enabled() {
@@ -832,6 +835,7 @@ func (g *{{.GCEWrapType}}) Insert(ctx context.Context, key *meta.Key, obj *{{.FQ
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("{{.GCEWrapType}}.Insert(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -875,6 +879,7 @@ func (g *{{.GCEWrapType}}) Delete(ctx context.Context, key *meta.Key) error {
 	call.Context(ctx)
 
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("{{.GCEWrapType}}.Delete(%v, %v) = %v", ctx, key, err)
 		return err
@@ -920,6 +925,7 @@ func (g *{{.GCEWrapType}}) AggregatedList(ctx context.Context, fl *filter.F) (ma
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("{{.GCEWrapType}}.AggregatedList(%v, %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -962,6 +968,7 @@ func (g *{{.GCEWrapType}}) ListUsable(ctx context.Context, fl *filter.F) ([]*{{.
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("{{.GCEWrapType}}.ListUsable(%v, ..., %v) = %v, %v", ctx, fl, nil, err)
 		return nil, err
 	}
@@ -1025,6 +1032,7 @@ func (g *{{.GCEWrapType}}) {{.FcnArgs}} {
 {{- if .IsOperation}}
 	call.Context(ctx)
 	op, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	if err != nil {
 		klog.V(4).Infof("{{.GCEWrapType}}.{{.Name}}(%v, %v, ...) = %+v", ctx, key, err)
 		return err
@@ -1035,6 +1043,7 @@ func (g *{{.GCEWrapType}}) {{.FcnArgs}} {
 {{- else if .IsGet}}
 	call.Context(ctx)
 	v, err := call.Do()
+	g.s.RateLimiter.Observe(ctx, err, rk)
 	klog.V(4).Infof("{{.GCEWrapType}}.{{.Name}}(%v, %v, ...) = %+v, %v", ctx, key, v, err)
 	return v, err
 {{- else if .IsPaged}}
@@ -1045,6 +1054,7 @@ func (g *{{.GCEWrapType}}) {{.FcnArgs}} {
 		return nil
 	}
 	if err := call.Pages(ctx, f); err != nil {
+		g.s.RateLimiter.Observe(ctx, err, rk)
 		klog.V(4).Infof("{{.GCEWrapType}}.{{.Name}}(%v, %v, ...) = %v, %v", ctx, key, nil, err)
 		return nil, err
 	}

--- a/pkg/cloud/gen_test.go
+++ b/pkg/cloud/gen_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
RateLimiter interface was extended with the Observe function to handle errors from responses