### PR TITLE
Add a way to get a map key to ResourceID

### DIFF
--- a/pkg/cloud/utils.go
+++ b/pkg/cloud/utils.go
@@ -49,17 +49,45 @@ type ResourceID struct {
 func (r *ResourceID) Equal(other *ResourceID) bool {
 	switch {
 	case r == nil && other == nil:
-	  return true
+		return true
 	case r == nil || other == nil:
-	  return false
+		return false
 	case r.ProjectID != other.ProjectID || r.Resource != other.Resource:
-	  return false
+		return false
 	case r.Key != nil && other.Key != nil:
-	  return *r.Key == *other.Key
+		return *r.Key == *other.Key
 	case r.Key == nil && other.Key == nil:
-	  return true
+		return true
 	default:
-	  return false
+		return false
+	}
+}
+
+// ResourceMapKey is a flat ResourceID that can be used as a key in maps.
+type ResourceMapKey struct {
+	ProjectID string
+	Resource  string
+	Name      string
+	Zone      string
+	Region    string
+}
+
+func (rk ResourceMapKey) ToID() *ResourceID {
+	return &ResourceID{
+		ProjectID: rk.ProjectID,
+		Resource:  rk.Resource,
+		Key:       &meta.Key{Name: rk.Name, Zone: rk.Zone, Region: rk.Region},
+	}
+}
+
+// MapKey returns a flat key that can be used for referencing in maps.
+func (r *ResourceID) MapKey() ResourceMapKey {
+	return ResourceMapKey{
+		ProjectID: r.ProjectID,
+		Resource:  r.Resource,
+		Name:      r.Key.Name,
+		Zone:      r.Key.Zone,
+		Region:    r.Key.Region,
 	}
 }
 
@@ -80,16 +108,16 @@ func (r *ResourceID) SelfLink(ver meta.Version) string {
 
 // ParseResourceURL parses resource URLs of the following formats:
 //
-//   global/<res>/<name>
-//   regions/<region>/<res>/<name>
-//   zones/<zone>/<res>/<name>
-//   projects/<proj>
-//   projects/<proj>/global/<res>/<name>
-//   projects/<proj>/regions/<region>/<res>/<name>
-//   projects/<proj>/zones/<zone>/<res>/<name>
-//   [https://www.googleapis.com/compute/<ver>]/projects/<proj>/global/<res>/<name>
-//   [https://www.googleapis.com/compute/<ver>]/projects/<proj>/regions/<region>/<res>/<name>
-//   [https://www.googleapis.com/compute/<ver>]/projects/<proj>/zones/<zone>/<res>/<name>
+//	global/<res>/<name>
+//	regions/<region>/<res>/<name>
+//	zones/<zone>/<res>/<name>
+//	projects/<proj>
+//	projects/<proj>/global/<res>/<name>
+//	projects/<proj>/regions/<region>/<res>/<name>
+//	projects/<proj>/zones/<zone>/<res>/<name>
+//	[https://www.googleapis.com/compute/<ver>]/projects/<proj>/global/<res>/<name>
+//	[https://www.googleapis.com/compute/<ver>]/projects/<proj>/regions/<region>/<res>/<name>
+//	[https://www.googleapis.com/compute/<ver>]/projects/<proj>/zones/<zone>/<res>/<name>
 func ParseResourceURL(url string) (*ResourceID, error) {
 	errNotValid := fmt.Errorf("%q is not a valid resource URL", url)
 


### PR DESCRIPTION
ResourceID uses meta.Key which is a pointer. This makes an easier (if awkward) way to use ResourceIDs as keys.