### PR TITLE
Change Fill() to be more customizable with the value being filled

### DIFF
--- a/pkg/cloud/api/fill.go
+++ b/pkg/cloud/api/fill.go
@@ -87,6 +87,10 @@ type filler struct {
 }
 
 func (f *filler) doBasic(p Path, v reflect.Value) (bool, error) {
+	if isNoFillPath(p) {
+		return false, nil
+	}
+
 	if isBasicV(v) {
 		v.Set(reflect.ValueOf(f.basicValue(v.Type(), p)))
 		return true, nil

--- a/pkg/cloud/api/fill_test.go
+++ b/pkg/cloud/api/fill_test.go
@@ -28,8 +28,21 @@ func TestFill(t *testing.T) {
 	}
 
 	type st struct {
-		I    int
-		S    string
+		I   int
+		I8  int8
+		I16 int16
+		I32 int32
+		I64 int64
+		U   uint
+		U8  uint8
+		U16 uint16
+		U32 uint32
+		U64 uint64
+		F32 float32
+		F64 float64
+		B   bool
+		S   string
+
 		PS   *string
 		IS   inner
 		PIS  *inner
@@ -40,6 +53,10 @@ func TestFill(t *testing.T) {
 		M    map[string]inner
 		MP   map[string]*inner
 		MLS  map[string][]string
+
+		NullFields      []string
+		ForceSendFields []string
+		ServerResponse  int // This isn't the accurate type, but suffices for our testing.
 	}
 
 	var s st
@@ -52,6 +69,18 @@ func TestFill(t *testing.T) {
 
 	want := st{
 		I:    111,
+		I8:   111,
+		I16:  111,
+		I32:  111,
+		I64:  111,
+		U:    111,
+		U8:   111,
+		U16:  111,
+		U32:  111,
+		U64:  111,
+		F32:  11.1,
+		F64:  11.1,
+		B:    true,
 		S:    "ZZZ",
 		PS:   &zzzStr,
 		IS:   inner{I: 111},
@@ -59,9 +88,9 @@ func TestFill(t *testing.T) {
 		LS:   []string{"ZZZ"},
 		LSt:  []inner{{I: 111}},
 		LPS:  []*string{&zzzStr},
-		LPSt: []*inner{&inner{I: 111}},
+		LPSt: []*inner{{I: 111}},
 		M:    map[string]inner{"ZZZ": {I: 111}},
-		MP:   map[string]*inner{"ZZZ": &inner{I: 111}},
+		MP:   map[string]*inner{"ZZZ": {I: 111}},
 		MLS:  map[string][]string{"ZZZ": {"ZZZ"}},
 	}
 	if diff := cmp.Diff(s, want); diff != "" {


### PR DESCRIPTION
- Customization for fill value.
- Defaults to static values to fill.
- Adds testing for all revelant types.