### PR TITLE
Hide and rename VersionedObj to `resource`; Add TypeTraitsFuncs

### DIFF
--- a/pkg/cloud/api/doc.go
+++ b/pkg/cloud/api/doc.go
@@ -22,11 +22,11 @@ limitations under the License.
 //
 // # Working with versioned API types.
 //
-// VersionedObject is used to write version-agnostic code such as
-// Kubernetes-style API translators.
+// Resource is used to write version-agnostic code such as Kubernetes-style API
+// translators.
 //
 //	 // Instantiate the adapter.
-//	 type Address = VersionedObject[compute.Address, alpha.Address, beta.Address]
+//	 type Address = NewResource[compute.Address, alpha.Address, beta.Address](...)
 //	 addr := Address{}
 //
 //	// Manipulate the fields in Address.
@@ -55,29 +55,12 @@ limitations under the License.
 //	    if errors.As(err, &objErrors) { /* handle MissingFields, etc. */ }
 //	}
 //
-// # Assumptions
-//
-// The code currently handles a narrow range of Go types:
-//
-//   - Root of the resource is a struct.
-//   - Struct fields are: basic type (e.g. int or string), pointer to a basic type,
-//     struct or pointer to struct, slice or map.
-//   - Map keys are basic type. map values are the same as struct fields.
-//   - Slice values are the same types as struct fields.
-//   - There are no recursive (cyclic) definitions (e.g. struct S that points (directly
-//     or indirectly) to S again.
-//   - Fields of the same name between version MUST be of the same basic, slice and
-//     map type. Struct can differ and are handled recusively.
-//
-// Exceptions to these rules can be handled by adding custom type conversions
-// (see below).
-//
 // # Checking type assumptions with unit tests
 //
-// VersionedObject.CheckSchema() can be used to check if the types referenced
-// meet the above criteria.
+// Resource.CheckSchema() can be used to check if the types referenced meet the
+// above criteria.
 //
-//	type Address = VersionedObject[compute.Address, alpha.Address, beta.Address]
+//	type Address = NewResource[compute.Address, alpha.Address, beta.Address](...)
 //	addr := Address{}
 //	if err := addr.CheckSchema(); err != nil { /* unsupported type schema */ }
 package api

--- a/pkg/cloud/api/type_trait.go
+++ b/pkg/cloud/api/type_trait.go
@@ -44,7 +44,7 @@ type TypeTrait[GA any, Alpha any, Beta any] interface {
 // reduce verbosity when creating a custom TypeTrait.
 type BaseTypeTrait[GA any, Alpha any, Beta any] struct{}
 
-// noTypeTrait implements TypeTrait.
+// Implements TypeTrait.
 func (*BaseTypeTrait[GA, Alpha, Beta]) CopyHelperGAtoAlpha(dest *Alpha, src *GA) error { return nil }
 func (*BaseTypeTrait[GA, Alpha, Beta]) CopyHelperGAtoBeta(dest *Beta, src *GA) error   { return nil }
 func (*BaseTypeTrait[GA, Alpha, Beta]) CopyHelperAlphaToGA(dest *GA, src *Alpha) error { return nil }
@@ -67,6 +67,61 @@ func NewFieldTraits() *FieldTraits {
 			},
 		},
 	}
+}
+
+// TypeTraitFuncs is a TypeTrait that takes func instead of defining an interface.
+type TypeTraitFuncs[GA any, Alpha any, Beta any] struct {
+	CopyHelperGAtoAlphaF   func(dest *Alpha, src *GA) error
+	CopyHelperGAtoBetaF    func(dest *Beta, src *GA) error
+	CopyHelperAlphaToGAF   func(dest *GA, src *Alpha) error
+	CopyHelperAlphaToBetaF func(dest *Beta, src *Alpha) error
+	CopyHelperBetaToGAF    func(dest *GA, src *Beta) error
+	CopyHelperBetaToAlphaF func(dest *Alpha, src *Beta) error
+	FieldTraitsF           func(meta.Version) *FieldTraits
+}
+
+// Implements TypeTrait.
+func (f *TypeTraitFuncs[GA, Alpha, Beta]) CopyHelperGAtoAlpha(dest *Alpha, src *GA) error {
+	if f.CopyHelperGAtoAlphaF == nil {
+		return nil
+	}
+	return f.CopyHelperGAtoAlphaF(dest, src)
+}
+func (f *TypeTraitFuncs[GA, Alpha, Beta]) CopyHelperGAtoBeta(dest *Beta, src *GA) error {
+	if f.CopyHelperGAtoBetaF == nil {
+		return nil
+	}
+	return f.CopyHelperGAtoBetaF(dest, src)
+}
+func (f *TypeTraitFuncs[GA, Alpha, Beta]) CopyHelperAlphaToGA(dest *GA, src *Alpha) error {
+	if f.CopyHelperAlphaToGAF == nil {
+		return nil
+	}
+	return f.CopyHelperAlphaToGAF(dest, src)
+}
+func (f *TypeTraitFuncs[GA, Alpha, Beta]) CopyHelperAlphaToBeta(dest *Beta, src *Alpha) error {
+	if f.CopyHelperAlphaToBetaF == nil {
+		return nil
+	}
+	return f.CopyHelperAlphaToBetaF(dest, src)
+}
+func (f *TypeTraitFuncs[GA, Alpha, Beta]) CopyHelperBetaToGA(dest *GA, src *Beta) error {
+	if f.CopyHelperBetaToGAF == nil {
+		return nil
+	}
+	return f.CopyHelperBetaToGAF(dest, src)
+}
+func (f *TypeTraitFuncs[GA, Alpha, Beta]) CopyHelperBetaToAlpha(dest *Alpha, src *Beta) error {
+	if f.CopyHelperBetaToAlphaF == nil {
+		return nil
+	}
+	return f.CopyHelperBetaToAlphaF(dest, src)
+}
+func (f *TypeTraitFuncs[GA, Alpha, Beta]) FieldTraits(v meta.Version) *FieldTraits {
+	if f.FieldTraitsF == nil {
+		return &FieldTraits{}
+	}
+	return f.FieldTraitsF(v)
 }
 
 // FieldTraits are the features and behavior for fields in the resource.


### PR DESCRIPTION
Hide and rename VersionedObj to `resource`
    
* Users of the package should not have access to create a zero-valued
  VersionedObj -- it is not valid.
* Adds ResourceID() to `resource`
* Adds testing for TypeTrait conversions overrides

Add TypeTraitsFuncs, struct to allow for less verbose simple TypeTraits
