### PR TITLE
Fix issue where Set() was validiting too much; simplify conversion code

### DIFF
--- a/pkg/cloud/api/resource_test.go
+++ b/pkg/cloud/api/resource_test.go
@@ -659,6 +659,13 @@ func TestResourceSetX(t *testing.T) {
 			gaErr:     true,
 			alphaErr:  true,
 		},
+		{
+			name:      "Set will ignore errors: zero fields not ForceSendFields",
+			src:       &ga{},
+			wantGA:    &ga{},
+			wantAlpha: &al{},
+			wantBeta:  &be{},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			res := newTestResource[ga, al, be](nil)


### PR DESCRIPTION
* Set() is used for taking GCE generated API objects. Due to the inconsistencies in GCE, these sometimes violate our (more strict) validation. Skip these validations for the time being. We may revisit this if we can see a way to handle the exceptions in behavior in a consistent way.
* Move the code into a type-erased dispatch. This removes some of the cut-and-paste due to types.
* Clarify that Set*() skips some of the validation of Access*()