### PR TITLE
Introduce a package-private type contextKey.

### DIFF
--- a/pkg/cloud/observe.go
+++ b/pkg/cloud/observe.go
@@ -32,7 +32,9 @@ type CallObserver interface {
 	End(ctx context.Context, key *RateLimitKey, err error)
 }
 
-var callObserverContextKey = &struct{}{}
+type contextKey string
+
+var callObserverContextKey = contextKey("call observer")
 
 // WithCallObserver adds a CallObserver that will be called on the
 // operation being called.
@@ -54,7 +56,7 @@ func callObserverStart(ctx context.Context, key *CallContextKey) {
 	}
 	co, ok := obj.(CallObserver)
 	if !ok {
-		panic(fmt.Sprintf("expected CallObserver, got %T", co))
+		panic(fmt.Sprintf("expected CallObserver, got %T", obj))
 	}
 	co.Start(ctx, key)
 }
@@ -66,7 +68,7 @@ func callObserverEnd(ctx context.Context, key *CallContextKey, err error) {
 	}
 	co, ok := obj.(CallObserver)
 	if !ok {
-		panic(fmt.Sprintf("expected CallObserver, got %T", co))
+		panic(fmt.Sprintf("expected CallObserver, got %T", obj))
 	}
 	co.End(ctx, key, err)
 }


### PR DESCRIPTION
Using &struct{}{} as a context key has a risk of running into collisions. Besides that enhance the logging instructions so they can better communicate the exact type that was extracted from context.