### PR TITLE
Add String() for ResourceID

### DIFF
--- a/pkg/cloud/utils.go
+++ b/pkg/cloud/utils.go
@@ -106,6 +106,16 @@ func (r *ResourceID) SelfLink(ver meta.Version) string {
 	return SelfLink(ver, r.ProjectID, r.Resource, r.Key)
 }
 
+func (r *ResourceID) String() string {
+	switch r.Key.Type() {
+	case meta.Zonal:
+		return fmt.Sprintf("%s:%s/%s/%s", r.Resource, r.ProjectID, r.Key.Zone, r.Key.Name)
+	case meta.Regional:
+		return fmt.Sprintf("%s:%s/%s/%s", r.Resource, r.ProjectID, r.Key.Region, r.Key.Name)
+	}
+	return fmt.Sprintf("%s:%s/%s", r.Resource, r.ProjectID, r.Key.Name)
+}
+
 // ParseResourceURL parses resource URLs of the following formats:
 //
 //	global/<res>/<name>

--- a/pkg/cloud/utils_test.go
+++ b/pkg/cloud/utils_test.go
@@ -79,6 +79,33 @@ func TestEqualResourceID(t *testing.T) {
 	}
 }
 
+func TestResourceIDString(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		id   *ResourceID
+		want string
+	}{
+		{
+			id:   &ResourceID{"proj1", "res1", meta.GlobalKey("key1")},
+			want: "res1:proj1/key1",
+		},
+		{
+			id:   &ResourceID{"proj1", "res1", meta.RegionalKey("key1", "us-central1")},
+			want: "res1:proj1/us-central1/key1",
+		},
+		{
+			id:   &ResourceID{"proj1", "res1", meta.ZonalKey("key1", "us-central1-c")},
+			want: "res1:proj1/us-central1-c/key1",
+		},
+	} {
+		got := tc.id.String()
+		if got != tc.want {
+			t.Errorf("String() = %q, want %q (id = %+v)", got, tc.want, tc.id)
+		}
+	}
+}
+
 func TestParseResourceURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This makes the debug output for ResourceID much easier to read.