### PR TITLE
Make SerialExecutor bail on bad arguments earlier

### DIFF
--- a/pkg/cloud/rgraph/exec/executor_serial_test.go
+++ b/pkg/cloud/rgraph/exec/executor_serial_test.go
@@ -96,10 +96,13 @@ func TestSerialExecutor(t *testing.T) {
 					actions := actionsFromGraphStr(tc.graph)
 
 					tr := NewGraphvizTracer()
-					ex := NewSerialExecutor(actions,
+					ex, err := NewSerialExecutor(actions,
 						ErrorStrategyOption(StopOnError),
 						TracerOption(tr),
 						DryRunOption(dryRun == "dry run"))
+					if err != nil {
+						t.Fatalf("NewSerialExecutor() = %v, want nil", err)
+					}
 					result, err := ex.Run(context.Background(), nil)
 					if gotErr := err != nil; gotErr != tc.wantErr {
 						t.Fatalf("Run() = %v; gotErr = %t, want %t", err, gotErr, tc.wantErr)
@@ -157,10 +160,13 @@ func TestSerialExecutorErrorStrategy(t *testing.T) {
 			actions := actionsFromGraphStr(tc.graph)
 
 			var tr GraphvizTracer
-			ex := NewSerialExecutor(actions,
+			ex, err := NewSerialExecutor(actions,
 				ErrorStrategyOption(tc.strategy),
 				TracerOption(&tr),
 				DryRunOption(false))
+			if err != nil {
+				t.Fatalf("NewSerialExecutor() = %v, want nil", err)
+			}
 			result, err := ex.Run(context.Background(), nil)
 			if gotErr := err != nil; gotErr != tc.wantErr {
 				t.Fatalf("Run() = %v; gotErr = %t, want %t", err, gotErr, tc.wantErr)


### PR DESCRIPTION
- Bail in the constructor of SerialExecutor
- Shortens some stuttering names