### PR TITLE
Fixes support for TcpRoute in the AppNet APIs

### DIFF
--- a/e2e/tcproute_test.go
+++ b/e2e/tcproute_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/kr/pretty"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/networkservices/v1"
+)
+
+func TestTcpRoute(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	bs := &compute.BackendService{
+		Name:                resourceName("bs1"),
+		Backends:            []*compute.Backend{},
+		LoadBalancingScheme: "INTERNAL_SELF_MANAGED",
+	}
+	bsKey := meta.GlobalKey(bs.Name)
+
+	t.Cleanup(func() {
+		err := theCloud.BackendServices().Delete(ctx, bsKey)
+		t.Logf("bs delete: %v", err)
+	})
+
+	// TcpRoute needs a BackendService to point to.
+	err := theCloud.BackendServices().Insert(ctx, bsKey, bs)
+	t.Logf("bs insert: %v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Current API does not support the new URL scheme.
+	serviceName := fmt.Sprintf("https://compute.googleapis.com/v1/projects/%s/global/backendServices/%s", testFlags.project, bs.Name)
+	tcpr := &networkservices.TcpRoute{
+		Name: resourceName("route1"),
+		Rules: []*networkservices.TcpRouteRouteRule{
+			{
+				Action: &networkservices.TcpRouteRouteAction{
+					Destinations: []*networkservices.TcpRouteRouteDestination{
+						{ServiceName: serviceName},
+					},
+				},
+			},
+		},
+	}
+	t.Logf("tcpr = %s", pretty.Sprint(tcpr))
+	tcprKey := meta.GlobalKey(tcpr.Name)
+
+	// Insert
+	t.Cleanup(func() {
+		err := theCloud.TcpRoutes().Delete(ctx, tcprKey)
+		t.Logf("tcpRoute delete: %v", err)
+	})
+
+	err = theCloud.TcpRoutes().Insert(ctx, tcprKey, tcpr)
+	t.Logf("tcproutes insert: %v", err)
+	if err != nil {
+		t.Fatalf("Insert() = %v", err)
+	}
+
+	// Get
+	tcpRoute, err := theCloud.TcpRoutes().Get(ctx, tcprKey)
+	t.Logf("tcpRoute = %s", pretty.Sprint(tcpRoute))
+	if err != nil {
+		t.Fatalf("Get(%s) = %v", tcprKey, err)
+	}
+
+	if len(tcpRoute.Rules) < 1 || len(tcpRoute.Rules[0].Action.Destinations) < 1 {
+		t.Fatalf("gotTcpRoute = %s, need at least one destination", pretty.Sprint(tcpRoute))
+	}
+	gotServiceName := tcpRoute.Rules[0].Action.Destinations[0].ServiceName
+	if gotServiceName != serviceName {
+		t.Fatalf("gotTcpRoute = %s, gotServiceName = %q, want %q", pretty.Sprint(tcpRoute), gotServiceName, serviceName)
+	}
+}

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -29,8 +29,6 @@ import (
 	"golang.org/x/oauth2/google"
 	"k8s.io/klog/v2"
 
-	alpha "google.golang.org/api/compute/v0.alpha"
-	beta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
@@ -79,26 +77,9 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	alpha, err := alpha.New(client)
+	svc, err := cloud.NewService(ctx, client, &cloud.SingleProjectRouter{ID: testFlags.project}, &cloud.NopRateLimiter{})
 	if err != nil {
 		log.Fatal(err)
-	}
-	beta, err := beta.New(client)
-	if err != nil {
-		log.Fatal(err)
-	}
-	ga, err := compute.New(client)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	svc := &cloud.Service{
-		GA:            ga,
-		Alpha:         alpha,
-		Beta:          beta,
-		ProjectRouter: &cloud.SingleProjectRouter{ID: testFlags.project},
-		RateLimiter:   &cloud.NopRateLimiter{},
 	}
 	theCloud = cloud.NewGCE(svc)
 

--- a/pkg/cloud/gen.go
+++ b/pkg/cloud/gen.go
@@ -46592,7 +46592,7 @@ func (g *TDTcpRoutes) Get(ctx context.Context, key *meta.Key, options ...Option)
 		klog.V(4).Infof("TDTcpRoutes.Get(%v, %v): RateLimiter error: %v", ctx, key, err)
 		return nil, err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/TcpRoutes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/tcpRoutes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesGA.TcpRoutes.Get(name)
 	call.Context(ctx)
 	v, err := call.Do()
@@ -46720,7 +46720,7 @@ func (g *TDTcpRoutes) Delete(ctx context.Context, key *meta.Key, options ...Opti
 		klog.V(4).Infof("TDTcpRoutes.Delete(%v, %v): RateLimiter error: %v", ctx, key, err)
 		return err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/TcpRoutes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/tcpRoutes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesGA.TcpRoutes.Delete(name)
 
 	call.Context(ctx)
@@ -46762,7 +46762,7 @@ func (g *TDTcpRoutes) Patch(ctx context.Context, key *meta.Key, arg0 *networkser
 		klog.V(4).Infof("TDTcpRoutes.Patch(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
 		return err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/TcpRoutes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/tcpRoutes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesGA.TcpRoutes.Patch(name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
@@ -47013,7 +47013,7 @@ func (g *TDBetaTcpRoutes) Get(ctx context.Context, key *meta.Key, options ...Opt
 		klog.V(4).Infof("TDBetaTcpRoutes.Get(%v, %v): RateLimiter error: %v", ctx, key, err)
 		return nil, err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/TcpRoutes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/tcpRoutes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesBeta.TcpRoutes.Get(name)
 	call.Context(ctx)
 	v, err := call.Do()
@@ -47141,7 +47141,7 @@ func (g *TDBetaTcpRoutes) Delete(ctx context.Context, key *meta.Key, options ...
 		klog.V(4).Infof("TDBetaTcpRoutes.Delete(%v, %v): RateLimiter error: %v", ctx, key, err)
 		return err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/TcpRoutes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/tcpRoutes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesBeta.TcpRoutes.Delete(name)
 
 	call.Context(ctx)
@@ -47183,7 +47183,7 @@ func (g *TDBetaTcpRoutes) Patch(ctx context.Context, key *meta.Key, arg0 *networ
 		klog.V(4).Infof("TDBetaTcpRoutes.Patch(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
 		return err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/TcpRoutes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/tcpRoutes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesBeta.TcpRoutes.Patch(name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
@@ -47434,7 +47434,7 @@ func (g *TDMeshes) Get(ctx context.Context, key *meta.Key, options ...Option) (*
 		klog.V(4).Infof("TDMeshes.Get(%v, %v): RateLimiter error: %v", ctx, key, err)
 		return nil, err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/Meshes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/meshes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesGA.Meshes.Get(name)
 	call.Context(ctx)
 	v, err := call.Do()
@@ -47561,7 +47561,7 @@ func (g *TDMeshes) Delete(ctx context.Context, key *meta.Key, options ...Option)
 		klog.V(4).Infof("TDMeshes.Delete(%v, %v): RateLimiter error: %v", ctx, key, err)
 		return err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/Meshes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/meshes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesGA.Meshes.Delete(name)
 
 	call.Context(ctx)
@@ -47603,7 +47603,7 @@ func (g *TDMeshes) Patch(ctx context.Context, key *meta.Key, arg0 *networkservic
 		klog.V(4).Infof("TDMeshes.Patch(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
 		return err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/Meshes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/meshes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesGA.Meshes.Patch(name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()
@@ -47854,7 +47854,7 @@ func (g *TDBetaMeshes) Get(ctx context.Context, key *meta.Key, options ...Option
 		klog.V(4).Infof("TDBetaMeshes.Get(%v, %v): RateLimiter error: %v", ctx, key, err)
 		return nil, err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/Meshes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/meshes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesBeta.Meshes.Get(name)
 	call.Context(ctx)
 	v, err := call.Do()
@@ -47981,7 +47981,7 @@ func (g *TDBetaMeshes) Delete(ctx context.Context, key *meta.Key, options ...Opt
 		klog.V(4).Infof("TDBetaMeshes.Delete(%v, %v): RateLimiter error: %v", ctx, key, err)
 		return err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/Meshes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/meshes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesBeta.Meshes.Delete(name)
 
 	call.Context(ctx)
@@ -48023,7 +48023,7 @@ func (g *TDBetaMeshes) Patch(ctx context.Context, key *meta.Key, arg0 *networkse
 		klog.V(4).Infof("TDBetaMeshes.Patch(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
 		return err
 	}
-	name := fmt.Sprintf("projects/%s/locations/global/Meshes/%s", projectID, key.Name)
+	name := fmt.Sprintf("projects/%s/locations/global/meshes/%s", projectID, key.Name)
 	call := g.s.NetworkServicesBeta.Meshes.Patch(name, arg0)
 	call.Context(ctx)
 	op, err := call.Do()

--- a/pkg/cloud/gen/main.go
+++ b/pkg/cloud/gen/main.go
@@ -769,7 +769,7 @@ func (g *{{.GCPWrapType}}) Get(ctx context.Context, key *meta.Key, options... Op
 		return nil, err
 	}
 {{- if .IsNetworkServices}}
-	name := fmt.Sprintf("projects/%s/locations/global/{{.Service}}/%s", projectID, key.Name)
+    name := fmt.Sprintf("{{.NetworkServicesFmt}}", projectID, key.Name)
 	call := g.s.{{.GroupVersionTitle}}.{{.Service}}.Get(name)
 {{- else}}
 	{{- if .KeyIsGlobal}}
@@ -962,7 +962,7 @@ func (g *{{.GCPWrapType}}) Delete(ctx context.Context, key *meta.Key, options...
 		return err
 	}
 {{- if .IsNetworkServices}}
-	name := fmt.Sprintf("projects/%s/locations/global/{{.Service}}/%s", projectID, key.Name)
+	name := fmt.Sprintf("{{.NetworkServicesFmt}}", projectID, key.Name)
 	call := g.s.{{.GroupVersionTitle}}.{{.Service}}.Delete(name)
 {{- else}}
 	{{- if .KeyIsGlobal}}
@@ -1140,7 +1140,7 @@ func (g *{{.GCPWrapType}}) {{.FcnArgs}} {
 	}
 
 {{- if .IsNetworkServices}}
-	name := fmt.Sprintf("projects/%s/locations/global/{{.Service}}/%s", projectID, key.Name)
+    name := fmt.Sprintf("{{.NetworkServicesFmt}}", projectID, key.Name)
 	call := g.s.{{.GroupVersionTitle}}.{{.Service}}.{{.Name}}(name {{.CallArgs}})
 {{- else}}
 	{{- if .KeyIsGlobal}}

--- a/pkg/cloud/meta/service.go
+++ b/pkg/cloud/meta/service.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"unicode"
 )
 
 // ServiceInfo defines the entry for a Service that code will be generated for.
@@ -114,6 +115,19 @@ func (i *ServiceInfo) ListItemName() string {
 		return i.Service
 	}
 	return "Items"
+}
+
+func (i *ServiceInfo) NetworkServicesFmt() string {
+	var scope string
+	switch i.keyType {
+	case Global:
+		scope = "global"
+	}
+
+	runes := []rune(i.Service)
+	serviceLower := append([]rune{unicode.ToLower(runes[0])}, runes[1:]...)
+
+	return `projects/%s/locations/` + scope + `/` + string(serviceLower) + `/%s`
 }
 
 // ObjectAggregatedListType is the compute List type for the object (contains Items field).

--- a/pkg/cloud/op_networkservices.go
+++ b/pkg/cloud/op_networkservices.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/networkservices/v1"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+)
+
+type networkServicesOperation struct {
+	s         *Service
+	projectID string
+	key       *meta.Key
+	err       error
+}
+
+func (o *networkServicesOperation) String() string {
+	return fmt.Sprintf("networkServicesOperation{%q, %s}", o.projectID, o.key)
+}
+
+func (o *networkServicesOperation) isDone(ctx context.Context) (bool, error) {
+	var (
+		op  *networkservices.Operation
+		err error
+	)
+
+	fqname := fmt.Sprintf("projects/%s/locations/global/operations/%s", o.projectID, o.key.Name)
+	klog.V(5).Infof("isDone %q", fqname)
+
+	switch o.key.Type() {
+	case meta.Global:
+		op, err = o.s.NetworkServicesGA.Operations.Get(fqname).Context(ctx).Do()
+		klog.V(5).Infof("GA.GlobalOperations.Get(%v, %v) = %+v, %v; ctx = %v", o.projectID, o.key.Name, op, err, ctx)
+	default:
+		return false, fmt.Errorf("invalid key type: %#v", o.key)
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	if op == nil || !op.Done {
+		return false, nil
+	}
+
+	if op.Error != nil {
+		o.err = &googleapi.Error{
+			Code:    int(op.Error.Code),
+			Message: fmt.Sprintf("%v - %v", op.Error.Code, op.Error.Message),
+		}
+	}
+	return true, nil
+}
+
+func (o *networkServicesOperation) rateLimitKey() *RateLimitKey {
+	return &RateLimitKey{
+		ProjectID: o.projectID,
+		Operation: "Get",
+		Service:   "Operations",
+		Version:   meta.VersionGA,
+	}
+}
+
+func (o *networkServicesOperation) error() error {
+	return o.err
+}
+
+type networkServiceOpURLParseResult struct {
+	projectID string
+	key       *meta.Key
+}
+
+// parseNetworkServiceOpURL parses the URL of the network services operation.
+// This is different than the `compute` API paths.
+func parseNetworkServiceOpURL(name string) (*networkServiceOpURLParseResult, error) {
+	// Format: projects/<projectID>/locations/global/operations/<Name>
+	//         0        1           2         3      4          5
+	split := strings.Split(name, "/")
+	const pieces = 6
+	if len(split) != pieces {
+		return nil, fmt.Errorf("invalid op URL %q, want %d pieces, got %d", name, 6, len(split))
+	}
+	if split[0] != "projects" || split[2] != "locations" || split[4] != "operations" {
+		return nil, fmt.Errorf("invalid op URL %q, did not match expected format", name)
+	}
+	if split[3] != "global" {
+		return nil, fmt.Errorf("only global ops are supported (URL was %q)", name)
+	}
+	return &networkServiceOpURLParseResult{
+		projectID: split[1],
+		key:       meta.GlobalKey(split[5]),
+	}, nil
+}

--- a/pkg/cloud/op_networkservices_test.go
+++ b/pkg/cloud/op_networkservices_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseNewtorkServiceOpURL(t *testing.T) {
+	t.Parallel()
+
+	type values struct {
+		Project string
+		Name    string
+	}
+
+	for _, tc := range []struct {
+		name    string
+		in      string
+		want    values
+		wantErr bool
+	}{
+		{
+			name:    "empty string",
+			wantErr: true,
+		},
+		{
+			name: "valid URL",
+			in:   "projects/project1/locations/global/operations/operation-name",
+			want: values{Project: "project1", Name: "operation-name"},
+		},
+		{
+			name:    "invalid URL path parts",
+			in:      "projects/project1/invalid/global/operations/operation-name",
+			wantErr: true,
+		},
+		{
+			name:    "invalid scope (only supports global)",
+			in:      "projects/project1/locations/us-central1/operations/operation-name",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL",
+			in:      "projects/x/y/z",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := parseNetworkServiceOpURL(tc.in)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("parseNetworkServiceOpURL() = _, %v; gotErr = %t, want %t", err, gotErr, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if r.key.Type() != meta.Global {
+				t.Errorf("parseNetworkServiceOpURL() = %v; want Global key", r)
+			}
+			got := values{r.projectID, r.key.Name}
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("parseNetworkServiceOpURL() = %v; cmp.Diff +got/-want: %s", r, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
    Fix various bugs needed to make TcpRoute resource work
    
    - Operations needs to be implemented
    - Various mismatches in the interface with the compute API

