### PR TITLE
add PlaceholderType

### DIFF
--- a/pkg/cloud/api/check_test.go
+++ b/pkg/cloud/api/check_test.go
@@ -258,6 +258,7 @@ func TestCheckSchema(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "ok", t: reflect.TypeOf(&okSt{})},
+		{name: "PlaceholderType is ok", t: reflect.TypeOf(&PlaceholderType{})},
 		{name: "fails cycle check", t: reflect.TypeOf(&rec2{}), wantErr: true},
 		{name: "fails type check", t: reflect.TypeOf(&badSt{}), wantErr: true},
 		{name: "fails type check bad fields", t: reflect.TypeOf(&badStFieldsBad{}), wantErr: true},

--- a/pkg/cloud/api/type.go
+++ b/pkg/cloud/api/type.go
@@ -20,6 +20,34 @@ import (
 	"reflect"
 )
 
+// PlaceholderType is used to represent GCE resource type versions that either
+// don't exist (e.g. there is not alpha version of the given resource) or we do
+// not intend to use (e.g. we omitted the type/version from being included in
+// pkg/cloud/meta).
+//
+// Example
+//
+//	// MyRes does not have an Alpha type:
+//	type MyRes Resource[ga.MyRes, PlaceholderType, beta.MyRes]
+type PlaceholderType struct {
+	// Standard fields that the system expects to always exist on a valid
+	// resource.
+	Name, SelfLink              string
+	NullFields, ForceSendFields []string
+}
+
+// isPlaceholderType returns true if T is of type PlaceHolderType or
+// *PlaceHolderType.
+func isPlaceholderType(t any) bool {
+	vb := reflect.ValueOf(t)
+	if vb.Kind() == reflect.Pointer {
+		_, ok := vb.Interface().(*PlaceholderType)
+		return ok
+	}
+	_, ok := vb.Interface().(PlaceholderType)
+	return ok
+}
+
 type kindPredicate func(t reflect.Type) bool
 
 func makeKindPredicate(kl ...reflect.Kind) kindPredicate {

--- a/pkg/cloud/api/type_test.go
+++ b/pkg/cloud/api/type_test.go
@@ -80,3 +80,60 @@ func TestTypeIsShortcuts(t *testing.T) {
 		}
 	}
 }
+
+func TestPlaceholerType(t *testing.T) {
+	type s1 struct{}
+	type s2 struct {
+		Name     string
+		SelfLink string
+
+		NullFields      []string
+		ForceSendFields []string
+	}
+
+	tcs := []struct {
+		desc string
+		t    interface{}
+		want bool
+	}{
+		{
+			desc: "PlaceholderType",
+			t:    PlaceholderType{},
+			want: true,
+		},
+		{
+			desc: "*PlaceholderType",
+			t:    &PlaceholderType{},
+			want: true,
+		},
+		{
+			desc: "empty struct type",
+			t:    s1{},
+			want: false,
+		},
+		{
+			desc: "pointer to an empty struct type",
+			t:    &s1{},
+			want: false,
+		},
+		{
+			desc: "struct with the same fields as PlaceholderType",
+			t:    s2{},
+			want: false,
+		},
+		{
+			desc: "pointer to a struct with the same fields as PlaceholderType",
+			t:    &s2{},
+			want: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := isPlaceholderType(tc.t)
+			if got != tc.want {
+				t.Errorf("isPlaceholderType(%T) = %v, want = %v", tc.t, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
PlaceholderType is used to represent GCE resource type versions that either
don't exist (e.g. there is not alpha version of the given resource) or we do
not intend to use (e.g. we omitted the type/version from being included in
pkg/cloud/meta).