### PR TITLE
Wrap coverage run in shell, fix inconsistency in results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,6 @@ build: gen
 	go build ./...
 	mkdir -p bin
 
-# COVTMP is the temp file used to check coverage.
-COVTMP := $(shell mktemp)
-
 .PHONY: test
 test: gen
 	# Test only the library. e2e must be run in a special environment,
@@ -38,9 +35,7 @@ test: gen
 	# golint ./...
 	go vet ./...
 	# Coverage
-	go test -cover ./pkg/... > $(COVTMP)
-	go run ./tools/checkcov.go -configFile ./tools/checkcov.yaml -covFile $(COVTMP)
-	rm -f $(COVTMP)
+	./tools/checkcov
 
 .PHONY: clean
 clean:

--- a/tools/checkcov
+++ b/tools/checkcov
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+shopt -s nullglob # empty glob expands to empty string
+
+out=$(mktemp)
+cleanup() {
+  rm "${out}"
+}
+trap cleanup EXIT
+
+for package in $(find ./pkg -type d); do
+  files=(${package}/*.go)
+  if [[ -z "${files}" ]]; then
+    echo "Skipping ${package}: no go files"
+    continue
+  fi
+  go test -cover "${package}" >> "${out}"
+done
+
+go run ./tools/checkcov.go \
+  -configFile ./tools/checkcov.yaml \
+  -covFile "${out}" \
+  -packagePrefix "github.com/GoogleCloudPlatform/k8s-cloud-provider/"

--- a/tools/checkcov.go
+++ b/tools/checkcov.go
@@ -40,6 +40,7 @@ var (
 	coverageOutputFile  = flag.String("covFile", "", "Output of go test -cover")
 	configFile          = flag.String("configFile", "", "Configuration file")
 	defaultCovThreshold = flag.Int("defaultCovThreshold", 80, "Default coverage percent.")
+	packagePrefix       = flag.String("packagePrefix", "", "Prefix of the go package")
 )
 
 const (
@@ -140,7 +141,8 @@ func checkOrDie(cov coverageResult, cfg *configFileData) {
 	var hasErr bool
 
 	for pkg, value := range cov {
-		entry, ok := cfg.Entries[pkg]
+		shortName := strings.TrimPrefix(pkg, *packagePrefix)
+		entry, ok := cfg.Entries[shortName]
 		if !ok {
 			// If an entry does not exist, assume default threshold.
 			entry = &covEntry{Expected: *defaultCovThreshold}

--- a/tools/checkcov.yaml
+++ b/tools/checkcov.yaml
@@ -1,59 +1,28 @@
 entries:
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud":
-        expected: 20 # generated code has low coverage
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/gen":
-        expected: 0 # Should be factored so it can be tested.
+    # generated code has low coverage
+    "pkg/cloud": { expected: 20 }
+    # Should be factored so it can be tested.
+    "pkg/cloud/gen": { expected: 0 }
+
     # can be improved
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/workflow/plan":
-        expected: 70
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/forwardingrule":
-        expected: 50
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta":
-        expected: 50
+    "pkg/cloud/rgraph/workflow/plan": { expected: 70 }
+    "pkg/cloud/rgraph/rnode/forwardingrule": { expected: 70 }
+    "pkg/cloud/rgraph/algo/trclosure": { expected: 70 }
+
     # low coverage packages
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/algo/localplan":
-        expected: 60
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph":
-        expected: 50
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/algo/traversal":
-        expected: 50
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode":
-        expected: 40
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/workflow/plan":
-        expected: 40
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/workflow/testlib":
-        expected: 40
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/algo/trclosure":
-        expected: 30
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/address":
-        expected: 20
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/algo/actions":
-        expected: 30
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode":
-        expected: 10
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/algo/graphviz":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/algo/snapshot":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/all":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/backendservice":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/fake":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/healthcheck":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/networkendpointgroup":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/targethttpproxy":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/urlmap":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/testing/ez":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/workflow/testlib":
-        expected: 0
-    "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/workflow/testlib/lb":
-        expected: 0
+    "pkg/cloud/meta": { expected: 50 }
+    "pkg/cloud/mock": { expected: 0 }
+    "pkg/cloud/rgraph/algo/graphviz": { expected: 0 }
+    "pkg/cloud/rgraph/algo/snapshot": { expected: 0 }
+    "pkg/cloud/rgraph/rnode": { expected: 10 }
+    "pkg/cloud/rgraph/rnode/address": { expected: 20 }
+    "pkg/cloud/rgraph/rnode/all": { expected: 0 }
+    "pkg/cloud/rgraph/rnode/backendservice": { expected: 0 }
+    "pkg/cloud/rgraph/rnode/fake": { expected: 0 }
+    "pkg/cloud/rgraph/rnode/healthcheck": { expected: 0 }
+    "pkg/cloud/rgraph/rnode/networkendpointgroup": { expected: 0 }
+    "pkg/cloud/rgraph/rnode/targethttpproxy": { expected: 0 }
+    "pkg/cloud/rgraph/rnode/urlmap": { expected: 0 }
+    "pkg/cloud/rgraph/testing/ez": { expected: 0 }
+    "pkg/cloud/rgraph/workflow/testlib": { expected: 0 }
+    "pkg/cloud/rgraph/workflow/testlib/lb": { expected: 0 }


### PR DESCRIPTION
- Wrap the coverage runner in a script for easier maintenance
- Running coverage over all of the packages in a single invocation seems to not give the same coverage numbers as running it on a single package basis. Run the coverage tool one package at a time for now.
- Add -packagePrefix to make the coverage file less verbose