### PR TITLE
Extract CheckStructuralSubset implementation.

### DIFF
--- a/pkg/cloud/api/check_test.go
+++ b/pkg/cloud/api/check_test.go
@@ -528,7 +528,7 @@ func TestConvertToT(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := CheckStructuralSubset(Path{}, reflect.TypeOf(tc.a), reflect.TypeOf(tc.b))
+			err := CheckStructuralSubset(reflect.TypeOf(tc.a), reflect.TypeOf(tc.b))
 			gotErr := err != nil
 			if gotErr != tc.wantErr {
 				t.Fatalf("CheckStructuralSubset() = %v; gotErr = %t, want %t", err, gotErr, tc.wantErr)

--- a/pkg/cloud/api/mutable_resource.go
+++ b/pkg/cloud/api/mutable_resource.go
@@ -222,7 +222,7 @@ func (u *mutableResource[GA, Alpha, Beta]) CheckSchema() error {
 
 func checkSubsetOf[T1 any, T2 any](t1 *T1, t2 *T2) error {
 
-	return CheckStructuralSubset(Path{}, reflect.TypeOf(t1), reflect.TypeOf(t2))
+	return CheckStructuralSubset(reflect.TypeOf(t1), reflect.TypeOf(t2))
 }
 
 func (u *mutableResource[GA, Alpha, Beta]) ResourceID() *cloud.ResourceID { return u.resourceID }


### PR DESCRIPTION
CheckStructuralSubset function has path passed for better error reporting. This implementation detail shouldn't be exposed in public API.