### PR TITLE
Deep copy path in Differ Results

### DIFF
--- a/pkg/cloud/api/diff.go
+++ b/pkg/cloud/api/diff.go
@@ -62,10 +62,12 @@ type DiffResult struct {
 func (r *DiffResult) HasDiff() bool { return len(r.Items) > 0 }
 
 func (r *DiffResult) add(state DiffItemState, p Path, a, b reflect.Value) {
+
 	di := DiffItem{
 		State: state,
-		Path:  p,
+		Path:  make([]string, len(p)),
 	}
+	copy(di.Path, p)
 	if a.IsValid() {
 		// Interface() will panic if is called on unexported types in this case
 		// the best we can do is to pass its name to the result.


### PR DESCRIPTION
Differ returns a Results list of all paths that mismatch. The list is a pair of paths and status.
The path is of type slice of strings.
We need to deep copy the path otherwise it will be overridden in the next iteration and as a result we will get all paths pointing to the same value.   