### PR TITLE
Set TCPRoute IdleTimeout to required field.

### DIFF
--- a/pkg/cloud/rgraph/rnode/tcproute/tcproute_test.go
+++ b/pkg/cloud/rgraph/rnode/tcproute/tcproute_test.go
@@ -279,6 +279,7 @@ func defaultTCPRouteResource(t *testing.T, id *cloud.ResourceID) MutableTcpRoute
 	trrr := &networkservices.TcpRouteRouteRule{
 		Action: &networkservices.TcpRouteRouteAction{
 			Destinations: []*networkservices.TcpRouteRouteDestination{d},
+			IdleTimeout:  "5",
 		},
 		Matches: []*networkservices.TcpRouteRouteMatch{},
 	}

--- a/pkg/cloud/rgraph/rnode/tcproute/type_trait.go
+++ b/pkg/cloud/rgraph/rnode/tcproute/type_trait.go
@@ -42,7 +42,6 @@ func (*tcpRouteTypeTrait) FieldTraits(meta.Version) *api.FieldTraits {
 	dt.AllowZeroValue(api.Path{}.Pointer().Field("Rules").AnySliceIndex().Pointer().Field("Action").Pointer().Field("Destinations").AnySliceIndex().Pointer().Field("Weight"))
 	dt.AllowZeroValue(api.Path{}.Pointer().Field("Rules").AnySliceIndex().Pointer().Field("Action").Pointer().Field("Destinations"))
 	dt.AllowZeroValue(api.Path{}.Pointer().Field("Rules").AnySliceIndex().Pointer().Field("Action").Pointer().Field("OriginalDestination"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Rules").AnySliceIndex().Pointer().Field("Action").Pointer().Field("IdleTimeout"))
 
 	return dt
 }


### PR DESCRIPTION
IdleTimeout has default value 30sec. If not set by the Client rGraph will perform unnecessary update for TCPRoute.