### PR TITLE
Fix TCP Route test

### DIFF
--- a/e2e/test-helpers.go
+++ b/e2e/test-helpers.go
@@ -127,3 +127,11 @@ Outer:
 		t.Fatalf("Rule ServiceName %s, not found in expected: %v", rule.Action.Destinations[0].ServiceName, svcIds)
 	}
 }
+
+func defaultNetworkURL() string {
+	return cloud.NewNetworksResourceID(testFlags.project, "default").SelfLink(meta.VersionGA)
+}
+
+func defaultSubnetworkURL() string {
+	return cloud.NewSubnetworksResourceID(testFlags.project, region, "default").SelfLink(meta.VersionGA)
+}


### PR DESCRIPTION
Previously, the tests relied on hardcoded names of NEGs created by
neg-controller in GKE cluster. Now all e2e tests can be run without GKE.