### PR TITLE
refactor executor

### DIFF
--- a/cmd/resgraph/viz/main.go
+++ b/cmd/resgraph/viz/main.go
@@ -154,13 +154,13 @@ func showStep(w http.ResponseWriter, cl cloud.Cloud, idx int, step *testlib.Step
 	outln("")
 
 	var viz exec.GraphvizTracer
-	ex, err := exec.NewSerialExecutor(result.Actions, exec.DryRunOption(false), exec.TracerOption(&viz))
+	ex, err := exec.NewSerialExecutor(cl, exec.DryRunOption(false), exec.TracerOption(&viz))
 	if err != nil {
 		outf("NewSerialExecutor() = %v, want nil", err)
 		return
 	}
 
-	execResult, err := ex.Run(context.Background(), cl)
+	execResult, err := ex.Run(context.Background(), result.Actions)
 
 	outln("<h3>Plan</h3>")
 	outln("")

--- a/e2e/rgraph_update_action_test.go
+++ b/e2e/rgraph_update_action_test.go
@@ -132,12 +132,12 @@ func TestHcUpdateWithBackendService(t *testing.T) {
 		t.Fatalf("plan.Do(_, _, _) = %v, want nil", err)
 	}
 
-	ex, err := exec.NewSerialExecutor(result.Actions)
+	ex, err := exec.NewSerialExecutor(theCloud)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor(_, _) err: %v", err)
 		return
 	}
-	res, err := ex.Run(ctx, theCloud)
+	res, err := ex.Run(ctx, result.Actions)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = %v, want nil", err)
 	}
@@ -182,12 +182,7 @@ func TestHcUpdateWithBackendService(t *testing.T) {
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 	t.Log("\nstart NewSerialExecutor for update")
-	ex, err = exec.NewSerialExecutor(result.Actions)
-	if err != nil {
-		t.Logf("exec.NewSerialExecutor err: %v", err)
-		return
-	}
-	res, err = ex.Run(ctx, theCloud)
+	res, err = ex.Run(ctx, result.Actions)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}
@@ -231,12 +226,7 @@ func TestHcUpdateWithBackendService(t *testing.T) {
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 	t.Log("\nstart NewSerialExecutor for update")
-	ex, err = exec.NewSerialExecutor(result.Actions)
-	if err != nil {
-		t.Logf("exec.NewSerialExecutor err: %v", err)
-		return
-	}
-	res, err = ex.Run(ctx, theCloud)
+	res, err = ex.Run(ctx, result.Actions)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}
@@ -265,12 +255,12 @@ func TestHcUpdateType(t *testing.T) {
 		t.Fatalf("plan.Do(_, _, _) = %v, want nil", err)
 	}
 
-	ex, err := exec.NewSerialExecutor(result.Actions)
+	ex, err := exec.NewSerialExecutor(theCloud)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor(_, _) err: %v", err)
 		return
 	}
-	res, err := ex.Run(ctx, theCloud)
+	res, err := ex.Run(ctx, result.Actions)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = %v, want nil", err)
 	}
@@ -309,12 +299,12 @@ func TestHcUpdateType(t *testing.T) {
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 	t.Log("\nstart NewSerialExecutor for update")
-	ex, err = exec.NewSerialExecutor(result.Actions)
+	ex, err = exec.NewSerialExecutor(theCloud)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor err: %v", err)
 		return
 	}
-	res, err = ex.Run(ctx, theCloud)
+	res, err = ex.Run(ctx, result.Actions)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}
@@ -348,12 +338,12 @@ func TestUpdateBackendService(t *testing.T) {
 		t.Fatalf("plan.Do(_, _, _) = %v, want nil", err)
 	}
 
-	ex, err := exec.NewSerialExecutor(result.Actions)
+	ex, err := exec.NewSerialExecutor(theCloud)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor(_, _) err: %v", err)
 		return
 	}
-	res, err := ex.Run(ctx, theCloud)
+	res, err := ex.Run(ctx, result.Actions)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = %v, want nil", err)
 	}
@@ -398,19 +388,14 @@ func TestUpdateBackendService(t *testing.T) {
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 	t.Log("\nstart NewSerialExecutor for update")
-	ex, err = exec.NewSerialExecutor(result.Actions)
-	if err != nil {
-		t.Logf("exec.NewSerialExecutor err: %v", err)
-		return
-	}
-	res, err = ex.Run(ctx, theCloud)
+	res, err = ex.Run(ctx, result.Actions)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}
 	t.Logf("exec.NewSerialExecutor finished, res: %v", res)
 	if len(res.Pending) > 0 {
 		t.Logf("Executor has %v, pending actions %v", len(res.Pending), res.Pending)
-		res, err = ex.Run(ctx, theCloud)
+		res, err = ex.Run(ctx, res.Pending)
 		if err != nil || res == nil {
 			t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 		}

--- a/e2e/tcproute_test.go
+++ b/e2e/tcproute_test.go
@@ -406,12 +406,12 @@ func processGraphAndExpectActions(t *testing.T, graphBuilder *rgraph.Builder, ex
 		t.Fatalf("expectActions(_, _) = %v, want nil", err)
 	}
 
-	ex, err := exec.NewSerialExecutor(result.Actions)
+	ex, err := exec.NewSerialExecutor(theCloud)
 	if err != nil {
 		t.Logf("exec.NewSerialExecutor err: %v", err)
 		return
 	}
-	res, err := ex.Run(context.Background(), theCloud)
+	res, err := ex.Run(context.Background(), result.Actions)
 	if err != nil || res == nil {
 		t.Errorf("ex.Run(_,_) = ( %v, %v), want (*result, nil)", res, err)
 	}

--- a/pkg/cloud/rgraph/exec/executor.go
+++ b/pkg/cloud/rgraph/exec/executor.go
@@ -19,8 +19,6 @@ package exec
 import (
 	"context"
 	"fmt"
-
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 )
 
 type Result struct {
@@ -42,7 +40,7 @@ type ActionWithErr struct {
 type Executor interface {
 	// Run the actions. Returns non-nil if there was an error in execution of
 	// one or more Actions.
-	Run(context.Context, cloud.Cloud) (*Result, error)
+	Run(context.Context, []Action) (*Result, error)
 }
 
 type Option func(*ExecutorConfig)

--- a/pkg/cloud/rgraph/exec/executor_serial_test.go
+++ b/pkg/cloud/rgraph/exec/executor_serial_test.go
@@ -96,14 +96,14 @@ func TestSerialExecutor(t *testing.T) {
 					actions := actionsFromGraphStr(tc.graph)
 
 					tr := NewGraphvizTracer()
-					ex, err := NewSerialExecutor(actions,
+					ex, err := NewSerialExecutor(nil,
 						ErrorStrategyOption(StopOnError),
 						TracerOption(tr),
 						DryRunOption(dryRun == "dry run"))
 					if err != nil {
 						t.Fatalf("NewSerialExecutor() = %v, want nil", err)
 					}
-					result, err := ex.Run(context.Background(), nil)
+					result, err := ex.Run(context.Background(), actions)
 					if gotErr := err != nil; gotErr != tc.wantErr {
 						t.Fatalf("Run() = %v; gotErr = %t, want %t", err, gotErr, tc.wantErr)
 					}
@@ -160,14 +160,14 @@ func TestSerialExecutorErrorStrategy(t *testing.T) {
 			actions := actionsFromGraphStr(tc.graph)
 
 			var tr GraphvizTracer
-			ex, err := NewSerialExecutor(actions,
+			ex, err := NewSerialExecutor(nil,
 				ErrorStrategyOption(tc.strategy),
 				TracerOption(&tr),
 				DryRunOption(false))
 			if err != nil {
 				t.Fatalf("NewSerialExecutor() = %v, want nil", err)
 			}
-			result, err := ex.Run(context.Background(), nil)
+			result, err := ex.Run(context.Background(), actions)
 			if gotErr := err != nil; gotErr != tc.wantErr {
 				t.Fatalf("Run() = %v; gotErr = %t, want %t", err, gotErr, tc.wantErr)
 			}

--- a/pkg/cloud/rgraph/workflow/plan/plan_test.go
+++ b/pkg/cloud/rgraph/workflow/plan/plan_test.go
@@ -133,11 +133,11 @@ func TestLB(t *testing.T) {
 	}
 
 	var viz exec.GraphvizTracer
-	ex, err := exec.NewSerialExecutor(res.Actions, exec.DryRunOption(true), exec.TracerOption(&viz))
+	ex, err := exec.NewSerialExecutor(nil, exec.DryRunOption(true), exec.TracerOption(&viz))
 	if err != nil {
 		t.Fatalf("NewSerialExecutor() = %v, want nil", err)
 	}
-	execResult, err := ex.Run(context.TODO(), nil)
+	execResult, err := ex.Run(context.TODO(), res.Actions)
 	for _, p := range execResult.Pending {
 		t.Logf("%+v", p.Metadata())
 	}


### PR DESCRIPTION
Change Executor `Run` function to accept as an input list of pending actions. This way we can implement retires and run Executor multiple times with different set of actions.

Change SerialExecutor constructor to accept cloud client as an input. 