### PR TITLE
Move functions using global test flags to *_test file

### DIFF
--- a/e2e/tcproute_test.go
+++ b/e2e/tcproute_test.go
@@ -432,3 +432,11 @@ func processGraphAndExpectActions(t *testing.T, graphBuilder *rgraph.Builder, ex
 	t.Logf("exec got Result.Errors len(%d) =\n%v", len(res.Errors), res.Errors)
 	t.Logf("exec got Result.Pending len(%d) =\n%v", len(res.Pending), res.Pending)
 }
+
+func defaultNetworkURL() string {
+	return cloud.NewNetworksResourceID(testFlags.project, "default").SelfLink(meta.VersionGA)
+}
+
+func defaultSubnetworkURL() string {
+	return cloud.NewSubnetworksResourceID(testFlags.project, region, "default").SelfLink(meta.VersionGA)
+}

--- a/e2e/test-helpers.go
+++ b/e2e/test-helpers.go
@@ -127,11 +127,3 @@ Outer:
 		t.Fatalf("Rule ServiceName %s, not found in expected: %v", rule.Action.Destinations[0].ServiceName, svcIds)
 	}
 }
-
-func defaultNetworkURL() string {
-	return cloud.NewNetworksResourceID(testFlags.project, "default").SelfLink(meta.VersionGA)
-}
-
-func defaultSubnetworkURL() string {
-	return cloud.NewSubnetworksResourceID(testFlags.project, region, "default").SelfLink(meta.VersionGA)
-}


### PR DESCRIPTION
Newly added helper functions were part of the package while the variables they depend on were defined in the *_test.go resulting in compile failures.

Alternative solutions:
1. Move test-helpers to helpers_test - all functions/variables in this file are unexported so it is useless as a package anyway
2. Add new arguments to newly added functions so they won't depend on global variables - helpers would be not that helpful and it would be better to inline them (as each is called only once)

/cc @kl52752
/assign @bowei