### PR TITLE
fix: Add MinimumRateLimiter configured to 50ms to e2e tests

### DIFF
--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"golang.org/x/oauth2/google"
@@ -77,7 +78,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	svc, err := cloud.NewService(ctx, client, &cloud.SingleProjectRouter{ID: testFlags.project}, &cloud.NopRateLimiter{})
+	mrl := &cloud.MinimumRateLimiter{RateLimiter: &cloud.NopRateLimiter{}, Minimum: 50 * time.Millisecond}
+	svc, err := cloud.NewService(ctx, client, &cloud.SingleProjectRouter{ID: testFlags.project}, mrl)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
When running e2e tests in the CI pipeline, we often hit `RATE_LIMIT_EXCEEDED` error. The quota is 1200 requests per minute. 50ms minimum wait before making a request guarantees we won't hit it (60*1000 / 1200).

(leaking timer is not concern in tests and is fixed in go 1.23+)

Bug: b/336784945