### PR TITLE
Parallel executor - remove default timeout value

### DIFF
--- a/pkg/cloud/rgraph/algo/parallel_queue.go
+++ b/pkg/cloud/rgraph/algo/parallel_queue.go
@@ -108,16 +108,18 @@ const (
 	stateDone
 )
 
-// Add an item to the queue. This method is threadsafe within op() and
-// can be called during Run(). It is NOT safe to call Add() from
-// a different, unassociated thread.
+// Add an item to the queue. This method is thread safe within op() and can be
+// called during Run(). It is NOT safe to call Add() from a different,
+// unassociated thread. This method returns an error when queue state is done.
 //
-// Calling Add(item) from the op() given to Run() guarantees that item
-// will be processed.
-func (q *ParallelQueue[T]) Add(item T) {
+// Calling Add(item) from the op() given to Run() guarantees that item will be
+// processed.
+func (q *ParallelQueue[T]) Add(item T) error {
 	q.lock.Lock()
 	defer q.lock.Unlock()
-
+	if q.state == stateDone {
+		return fmt.Errorf("Queue is done")
+	}
 	qe := queueElement[T]{
 		ri: RunInfo{
 			ID:     item.String(),
@@ -136,6 +138,7 @@ func (q *ParallelQueue[T]) Add(item T) {
 		// the <-q.in will happen AFTER append(q.pending).
 		q.in <- struct{}{}
 	}
+	return nil
 }
 
 // Run the queue using op() to process each task. Different op()s must

--- a/pkg/cloud/rgraph/algo/parallel_queue.go
+++ b/pkg/cloud/rgraph/algo/parallel_queue.go
@@ -110,15 +110,15 @@ const (
 
 // Add an item to the queue. This method is thread safe within op() and can be
 // called during Run(). It is NOT safe to call Add() from a different,
-// unassociated thread. This method returns an error when queue state is done.
+// unassociated thread. This method returns False when queue state is done.
 //
 // Calling Add(item) from the op() given to Run() guarantees that item will be
 // processed.
-func (q *ParallelQueue[T]) Add(item T) error {
+func (q *ParallelQueue[T]) Add(item T) bool {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	if q.state == stateDone {
-		return fmt.Errorf("Queue is done")
+		return false
 	}
 	qe := queueElement[T]{
 		ri: RunInfo{
@@ -138,7 +138,7 @@ func (q *ParallelQueue[T]) Add(item T) error {
 		// the <-q.in will happen AFTER append(q.pending).
 		q.in <- struct{}{}
 	}
-	return nil
+	return true
 }
 
 // Run the queue using op() to process each task. Different op()s must

--- a/pkg/cloud/rgraph/algo/parallel_queue_test.go
+++ b/pkg/cloud/rgraph/algo/parallel_queue_test.go
@@ -352,17 +352,25 @@ func TestParallelQueueWaitForOrphans(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	taskc := newTaskControl(q)
-	q.Add(taskc.newTask("a", []step{
+	err := q.Add(taskc.newTask("a", []step{
 		{f: func() { cancel() }},
 		{wait: "done"},
 		{sleep: 10 * time.Millisecond},
 	}))
+	if err != nil {
+		t.Fatalf("q.Add(_) = %v, want nil", err)
+	}
 	q.Run(ctx, taskc.queueOp) // ignore err
 	// Unblock the task.
 	taskc.stepSignal("done")
 	// WaitForOrphans should return when the task is done.
-	err := q.WaitForOrphans(context.Background())
+	err = q.WaitForOrphans(context.Background())
 	if err != nil {
 		t.Fatalf("q.Run() = %v; want nil", err)
+	}
+	// Check that queue will return an error on Add() when queue state is done.
+	err = q.Add(taskc.newTask("a", nil))
+	if err == nil {
+		t.Fatal("q.Add(_) = nil, want error")
 	}
 }

--- a/pkg/cloud/rgraph/algo/trclosure/transitive_closure.go
+++ b/pkg/cloud/rgraph/algo/trclosure/transitive_closure.go
@@ -96,8 +96,8 @@ func doInternal(
 	config := makeConfig(opts...)
 
 	for _, nb := range gr.All() {
-		if err := pq.Add(work{b: nb}); err != nil {
-			return fmt.Errorf("transitive closure Do() = %w", err)
+		if ok := pq.Add(work{b: nb}); !ok {
+			return fmt.Errorf("parallel queue is done")
 		}
 	}
 
@@ -135,8 +135,8 @@ func doInternal(
 			gr.Add(toNode)
 			graphLock.Unlock()
 
-			if err := pq.Add(work{b: toNode}); err != nil {
-				return fmt.Errorf("transitive closure Do() = %w", err)
+			if ok := pq.Add(work{b: toNode}); !ok {
+				return fmt.Errorf("parallel queue is done")
 			}
 		}
 

--- a/pkg/cloud/rgraph/algo/trclosure/transitive_closure.go
+++ b/pkg/cloud/rgraph/algo/trclosure/transitive_closure.go
@@ -96,7 +96,9 @@ func doInternal(
 	config := makeConfig(opts...)
 
 	for _, nb := range gr.All() {
-		pq.Add(work{b: nb})
+		if err := pq.Add(work{b: nb}); err != nil {
+			return fmt.Errorf("transitive closure Do() = %w", err)
+		}
 	}
 
 	// graphLock is held when updating gr (rgraph.Builder).
@@ -133,7 +135,9 @@ func doInternal(
 			gr.Add(toNode)
 			graphLock.Unlock()
 
-			pq.Add(work{b: toNode})
+			if err := pq.Add(work{b: toNode}); err != nil {
+				return fmt.Errorf("transitive closure Do() = %w", err)
+			}
 		}
 
 		return nil

--- a/pkg/cloud/rgraph/exec/executor.go
+++ b/pkg/cloud/rgraph/exec/executor.go
@@ -32,6 +32,18 @@ type Result struct {
 	Pending []Action
 }
 
+func (r *Result) DeepCopy() *Result {
+	resultCopy := Result{
+		Completed: make([]Action, len(r.Completed)),
+		Pending:   make([]Action, len(r.Pending)),
+		Errors:    make([]ActionWithErr, len(r.Errors)),
+	}
+	copy(resultCopy.Completed, r.Completed)
+	copy(resultCopy.Errors, r.Errors)
+	copy(resultCopy.Pending, r.Pending)
+	return &resultCopy
+}
+
 type ActionWithErr struct {
 	Action Action
 	Err    error

--- a/pkg/cloud/rgraph/exec/executor_parallel.go
+++ b/pkg/cloud/rgraph/exec/executor_parallel.go
@@ -150,7 +150,10 @@ func (ex *parallelExecutor) queueRunnableActions() {
 	for _, a := range ex.result.Pending {
 		if a.CanRun() {
 			klog.V(4).Infof("Run task: %s", a)
-			ex.pq.Add(a)
+			if err := ex.pq.Add(a); err != nil {
+				klog.Errorf("error adding task %s to parallel queue: %v", a, err)
+				break
+			}
 			taskWasRun = true
 		} else {
 			notRunnable = append(notRunnable, a)


### PR DESCRIPTION
Remove default timeout values for action timeout and waitForOrphans timeout. If timeout is not set then do not create context with cancel.

Run function returns Result as a pointer. Deep copy the result to avoid race conditions when waitForOrphans function timeouts and not all actions were processed. 

Add IsDone function to parallel queue to check queue status and prevent scheduling new tasks while waiting for orphans.