### PR TITLE
Add impersonation option to e2e tests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 h1:4Pp6oUg3+e/6M4C0A/3kJ2VYa++dsWVTtGgLVj5xtHg=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0/go.mod h1:Mjt1i1INqiaoZOMGR1RIUJN+i3ChKoFRqzrRQhlkbs0=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 h1:jq9TW8u3so/bN+JPT166wjOI6/vQPF6Xe7nMNIltagk=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0/go.mod h1:p8pYQP+m5XfbZm9fxtSKAbM6oIllS7s2AfxrChvc7iw=
 go.opentelemetry.io/otel v1.24.0 h1:0LAOdjNmQeSTzGBzduGe/rU4tZhMwL5rWgtp9Ku5Jfo=
@@ -138,6 +140,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
+golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/vendor/google.golang.org/api/impersonate/doc.go
+++ b/vendor/google.golang.org/api/impersonate/doc.go
@@ -1,0 +1,32 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package impersonate is used to impersonate Google Credentials.
+//
+// # Required IAM roles
+//
+// In order to impersonate a service account the base service account must have
+// the Service Account Token Creator role, roles/iam.serviceAccountTokenCreator,
+// on the service account being impersonated. See
+// https://cloud.google.com/iam/docs/understanding-service-accounts.
+//
+// Optionally, delegates can be used during impersonation if the base service
+// account lacks the token creator role on the target. When using delegates,
+// each service account must be granted roles/iam.serviceAccountTokenCreator
+// on the next service account in the delgation chain.
+//
+// For example, if a base service account of SA1 is trying to impersonate target
+// service account SA2 while using delegate service accounts DSA1 and DSA2,
+// the following must be true:
+//
+//  1. Base service account SA1 has roles/iam.serviceAccountTokenCreator on
+//     DSA1.
+//  2. DSA1 has roles/iam.serviceAccountTokenCreator on DSA2.
+//  3. DSA2 has roles/iam.serviceAccountTokenCreator on target SA2.
+//
+// If the base credential is an authorized user and not a service account, or if
+// the option WithQuotaProject is set, the target service account must have a
+// role that grants the serviceusage.services.use permission such as
+// roles/serviceusage.serviceUsageConsumer.
+package impersonate

--- a/vendor/google.golang.org/api/impersonate/idtoken.go
+++ b/vendor/google.golang.org/api/impersonate/idtoken.go
@@ -1,0 +1,128 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package impersonate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+	htransport "google.golang.org/api/transport/http"
+)
+
+// IDTokenConfig for generating an impersonated ID token.
+type IDTokenConfig struct {
+	// Audience is the `aud` field for the token, such as an API endpoint the
+	// token will grant access to. Required.
+	Audience string
+	// TargetPrincipal is the email address of the service account to
+	// impersonate. Required.
+	TargetPrincipal string
+	// IncludeEmail includes the service account's email in the token. The
+	// resulting token will include both an `email` and `email_verified`
+	// claim.
+	IncludeEmail bool
+	// Delegates are the service account email addresses in a delegation chain.
+	// Each service account must be granted roles/iam.serviceAccountTokenCreator
+	// on the next service account in the chain. Optional.
+	Delegates []string
+}
+
+// IDTokenSource creates an impersonated TokenSource that returns ID tokens
+// configured with the provided config and using credentials loaded from
+// Application Default Credentials as the base credentials. The tokens provided
+// by the source are valid for one hour and are automatically refreshed.
+func IDTokenSource(ctx context.Context, config IDTokenConfig, opts ...option.ClientOption) (oauth2.TokenSource, error) {
+	if config.Audience == "" {
+		return nil, fmt.Errorf("impersonate: an audience must be provided")
+	}
+	if config.TargetPrincipal == "" {
+		return nil, fmt.Errorf("impersonate: a target service account must be provided")
+	}
+
+	clientOpts := append(defaultClientOptions(), opts...)
+	client, _, err := htransport.NewClient(ctx, clientOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	its := impersonatedIDTokenSource{
+		client:          client,
+		targetPrincipal: config.TargetPrincipal,
+		audience:        config.Audience,
+		includeEmail:    config.IncludeEmail,
+	}
+	for _, v := range config.Delegates {
+		its.delegates = append(its.delegates, formatIAMServiceAccountName(v))
+	}
+	return oauth2.ReuseTokenSource(nil, its), nil
+}
+
+type generateIDTokenRequest struct {
+	Audience     string   `json:"audience"`
+	IncludeEmail bool     `json:"includeEmail"`
+	Delegates    []string `json:"delegates,omitempty"`
+}
+
+type generateIDTokenResponse struct {
+	Token string `json:"token"`
+}
+
+type impersonatedIDTokenSource struct {
+	client *http.Client
+
+	targetPrincipal string
+	audience        string
+	includeEmail    bool
+	delegates       []string
+}
+
+func (i impersonatedIDTokenSource) Token() (*oauth2.Token, error) {
+	now := time.Now()
+	genIDTokenReq := generateIDTokenRequest{
+		Audience:     i.audience,
+		IncludeEmail: i.includeEmail,
+		Delegates:    i.delegates,
+	}
+	bodyBytes, err := json.Marshal(genIDTokenReq)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to marshal request: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/%s:generateIdToken", iamCredentailsEndpoint, formatIAMServiceAccountName(i.targetPrincipal))
+	req, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := i.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to generate ID token: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to read body: %v", err)
+	}
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("impersonate: status code %d: %s", c, body)
+	}
+
+	var generateIDTokenResp generateIDTokenResponse
+	if err := json.Unmarshal(body, &generateIDTokenResp); err != nil {
+		return nil, fmt.Errorf("impersonate: unable to parse response: %v", err)
+	}
+	return &oauth2.Token{
+		AccessToken: generateIDTokenResp.Token,
+		// Generated ID tokens are good for one hour.
+		Expiry: now.Add(1 * time.Hour),
+	}, nil
+}

--- a/vendor/google.golang.org/api/impersonate/impersonate.go
+++ b/vendor/google.golang.org/api/impersonate/impersonate.go
@@ -1,0 +1,209 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package impersonate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/internal"
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+	htransport "google.golang.org/api/transport/http"
+)
+
+var (
+	iamCredentailsEndpoint                      = "https://iamcredentials.googleapis.com"
+	oauth2Endpoint                              = "https://oauth2.googleapis.com"
+	errMissingTargetPrincipal                   = errors.New("impersonate: a target service account must be provided")
+	errMissingScopes                            = errors.New("impersonate: scopes must be provided")
+	errLifetimeOverMax                          = errors.New("impersonate: max lifetime is 12 hours")
+	errUniverseNotSupportedDomainWideDelegation = errors.New("impersonate: service account user is configured for the credential. " +
+		"Domain-wide delegation is not supported in universes other than googleapis.com")
+)
+
+// CredentialsConfig for generating impersonated credentials.
+type CredentialsConfig struct {
+	// TargetPrincipal is the email address of the service account to
+	// impersonate. Required.
+	TargetPrincipal string
+	// Scopes that the impersonated credential should have. Required.
+	Scopes []string
+	// Delegates are the service account email addresses in a delegation chain.
+	// Each service account must be granted roles/iam.serviceAccountTokenCreator
+	// on the next service account in the chain. Optional.
+	Delegates []string
+	// Lifetime is the amount of time until the impersonated token expires. If
+	// unset the token's lifetime will be one hour and be automatically
+	// refreshed. If set the token may have a max lifetime of one hour and will
+	// not be refreshed. Service accounts that have been added to an org policy
+	// with constraints/iam.allowServiceAccountCredentialLifetimeExtension may
+	// request a token lifetime of up to 12 hours. Optional.
+	Lifetime time.Duration
+	// Subject is the sub field of a JWT. This field should only be set if you
+	// wish to impersonate as a user. This feature is useful when using domain
+	// wide delegation. Optional.
+	Subject string
+}
+
+// defaultClientOptions ensures the base credentials will work with the IAM
+// Credentials API if no scope or audience is set by the user.
+func defaultClientOptions() []option.ClientOption {
+	return []option.ClientOption{
+		internaloption.WithDefaultAudience("https://iamcredentials.googleapis.com/"),
+		internaloption.WithDefaultScopes("https://www.googleapis.com/auth/cloud-platform"),
+	}
+}
+
+// CredentialsTokenSource returns an impersonated CredentialsTokenSource configured with the provided
+// config and using credentials loaded from Application Default Credentials as
+// the base credentials.
+func CredentialsTokenSource(ctx context.Context, config CredentialsConfig, opts ...option.ClientOption) (oauth2.TokenSource, error) {
+	if config.TargetPrincipal == "" {
+		return nil, errMissingTargetPrincipal
+	}
+	if len(config.Scopes) == 0 {
+		return nil, errMissingScopes
+	}
+	if config.Lifetime.Hours() > 12 {
+		return nil, errLifetimeOverMax
+	}
+
+	var isStaticToken bool
+	// Default to the longest acceptable value of one hour as the token will
+	// be refreshed automatically if not set.
+	lifetime := 3600 * time.Second
+	if config.Lifetime != 0 {
+		lifetime = config.Lifetime
+		// Don't auto-refresh token if a lifetime is configured.
+		isStaticToken = true
+	}
+
+	clientOpts := append(defaultClientOptions(), opts...)
+	client, _, err := htransport.NewClient(ctx, clientOpts...)
+	if err != nil {
+		return nil, err
+	}
+	// If a subject is specified a domain-wide delegation auth-flow is initiated
+	// to impersonate as the provided subject (user).
+	if config.Subject != "" {
+		settings, err := newSettings(clientOpts)
+		if err != nil {
+			return nil, err
+		}
+		if !settings.IsUniverseDomainGDU() {
+			return nil, errUniverseNotSupportedDomainWideDelegation
+		}
+		return user(ctx, config, client, lifetime, isStaticToken)
+	}
+
+	its := impersonatedTokenSource{
+		client:          client,
+		targetPrincipal: config.TargetPrincipal,
+		lifetime:        fmt.Sprintf("%.fs", lifetime.Seconds()),
+	}
+	for _, v := range config.Delegates {
+		its.delegates = append(its.delegates, formatIAMServiceAccountName(v))
+	}
+	its.scopes = make([]string, len(config.Scopes))
+	copy(its.scopes, config.Scopes)
+
+	if isStaticToken {
+		tok, err := its.Token()
+		if err != nil {
+			return nil, err
+		}
+		return oauth2.StaticTokenSource(tok), nil
+	}
+	return oauth2.ReuseTokenSource(nil, its), nil
+}
+
+func newSettings(opts []option.ClientOption) (*internal.DialSettings, error) {
+	var o internal.DialSettings
+	for _, opt := range opts {
+		opt.Apply(&o)
+	}
+	if err := o.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &o, nil
+}
+
+func formatIAMServiceAccountName(name string) string {
+	return fmt.Sprintf("projects/-/serviceAccounts/%s", name)
+}
+
+type generateAccessTokenReq struct {
+	Delegates []string `json:"delegates,omitempty"`
+	Lifetime  string   `json:"lifetime,omitempty"`
+	Scope     []string `json:"scope,omitempty"`
+}
+
+type generateAccessTokenResp struct {
+	AccessToken string `json:"accessToken"`
+	ExpireTime  string `json:"expireTime"`
+}
+
+type impersonatedTokenSource struct {
+	client *http.Client
+
+	targetPrincipal string
+	lifetime        string
+	scopes          []string
+	delegates       []string
+}
+
+// Token returns an impersonated Token.
+func (i impersonatedTokenSource) Token() (*oauth2.Token, error) {
+	reqBody := generateAccessTokenReq{
+		Delegates: i.delegates,
+		Lifetime:  i.lifetime,
+		Scope:     i.scopes,
+	}
+	b, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to marshal request: %v", err)
+	}
+	url := fmt.Sprintf("%s/v1/%s:generateAccessToken", iamCredentailsEndpoint, formatIAMServiceAccountName(i.targetPrincipal))
+	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := i.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to generate access token: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to read body: %v", err)
+	}
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("impersonate: status code %d: %s", c, body)
+	}
+
+	var accessTokenResp generateAccessTokenResp
+	if err := json.Unmarshal(body, &accessTokenResp); err != nil {
+		return nil, fmt.Errorf("impersonate: unable to parse response: %v", err)
+	}
+	expiry, err := time.Parse(time.RFC3339, accessTokenResp.ExpireTime)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to parse expiry: %v", err)
+	}
+	return &oauth2.Token{
+		AccessToken: accessTokenResp.AccessToken,
+		Expiry:      expiry,
+	}, nil
+}

--- a/vendor/google.golang.org/api/impersonate/user.go
+++ b/vendor/google.golang.org/api/impersonate/user.go
@@ -1,0 +1,170 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package impersonate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// user provides an auth flow for domain-wide delegation, setting
+// CredentialsConfig.Subject to be the impersonated user.
+func user(ctx context.Context, c CredentialsConfig, client *http.Client, lifetime time.Duration, isStaticToken bool) (oauth2.TokenSource, error) {
+	u := userTokenSource{
+		client:          client,
+		targetPrincipal: c.TargetPrincipal,
+		subject:         c.Subject,
+		lifetime:        lifetime,
+	}
+	u.delegates = make([]string, len(c.Delegates))
+	for i, v := range c.Delegates {
+		u.delegates[i] = formatIAMServiceAccountName(v)
+	}
+	u.scopes = make([]string, len(c.Scopes))
+	copy(u.scopes, c.Scopes)
+	if isStaticToken {
+		tok, err := u.Token()
+		if err != nil {
+			return nil, err
+		}
+		return oauth2.StaticTokenSource(tok), nil
+	}
+	return oauth2.ReuseTokenSource(nil, u), nil
+}
+
+type claimSet struct {
+	Iss   string `json:"iss"`
+	Scope string `json:"scope,omitempty"`
+	Sub   string `json:"sub,omitempty"`
+	Aud   string `json:"aud"`
+	Iat   int64  `json:"iat"`
+	Exp   int64  `json:"exp"`
+}
+
+type signJWTRequest struct {
+	Payload   string   `json:"payload"`
+	Delegates []string `json:"delegates,omitempty"`
+}
+
+type signJWTResponse struct {
+	// KeyID is the key used to sign the JWT.
+	KeyID string `json:"keyId"`
+	// SignedJwt contains the automatically generated header; the
+	// client-supplied payload; and the signature, which is generated using
+	// the key referenced by the `kid` field in the header.
+	SignedJWT string `json:"signedJwt"`
+}
+
+type exchangeTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int64  `json:"expires_in"`
+}
+
+type userTokenSource struct {
+	client *http.Client
+
+	targetPrincipal string
+	subject         string
+	scopes          []string
+	lifetime        time.Duration
+	delegates       []string
+}
+
+func (u userTokenSource) Token() (*oauth2.Token, error) {
+	signedJWT, err := u.signJWT()
+	if err != nil {
+		return nil, err
+	}
+	return u.exchangeToken(signedJWT)
+}
+
+func (u userTokenSource) signJWT() (string, error) {
+	now := time.Now()
+	exp := now.Add(u.lifetime)
+	claims := claimSet{
+		Iss:   u.targetPrincipal,
+		Scope: strings.Join(u.scopes, " "),
+		Sub:   u.subject,
+		Aud:   fmt.Sprintf("%s/token", oauth2Endpoint),
+		Iat:   now.Unix(),
+		Exp:   exp.Unix(),
+	}
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to marshal claims: %v", err)
+	}
+	signJWTReq := signJWTRequest{
+		Payload:   string(payloadBytes),
+		Delegates: u.delegates,
+	}
+
+	bodyBytes, err := json.Marshal(signJWTReq)
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to marshal request: %v", err)
+	}
+	reqURL := fmt.Sprintf("%s/v1/%s:signJwt", iamCredentailsEndpoint, formatIAMServiceAccountName(u.targetPrincipal))
+	req, err := http.NewRequest("POST", reqURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	rawResp, err := u.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to sign JWT: %v", err)
+	}
+	body, err := io.ReadAll(io.LimitReader(rawResp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("impersonate: unable to read body: %v", err)
+	}
+	if c := rawResp.StatusCode; c < 200 || c > 299 {
+		return "", fmt.Errorf("impersonate: status code %d: %s", c, body)
+	}
+
+	var signJWTResp signJWTResponse
+	if err := json.Unmarshal(body, &signJWTResp); err != nil {
+		return "", fmt.Errorf("impersonate: unable to parse response: %v", err)
+	}
+	return signJWTResp.SignedJWT, nil
+}
+
+func (u userTokenSource) exchangeToken(signedJWT string) (*oauth2.Token, error) {
+	now := time.Now()
+	v := url.Values{}
+	v.Set("grant_type", "assertion")
+	v.Set("assertion_type", "http://oauth.net/grant_type/jwt/1.0/bearer")
+	v.Set("assertion", signedJWT)
+	rawResp, err := u.client.PostForm(fmt.Sprintf("%s/token", oauth2Endpoint), v)
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to exchange token: %v", err)
+	}
+	body, err := io.ReadAll(io.LimitReader(rawResp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("impersonate: unable to read body: %v", err)
+	}
+	if c := rawResp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("impersonate: status code %d: %s", c, body)
+	}
+
+	var tokenResp exchangeTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("impersonate: unable to parse response: %v", err)
+	}
+
+	return &oauth2.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		Expiry:      now.Add(time.Second * time.Duration(tokenResp.ExpiresIn)),
+	}, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -163,6 +163,7 @@ google.golang.org/api/compute/v0.beta
 google.golang.org/api/compute/v1
 google.golang.org/api/googleapi
 google.golang.org/api/googleapi/transport
+google.golang.org/api/impersonate
 google.golang.org/api/internal
 google.golang.org/api/internal/cert
 google.golang.org/api/internal/gensupport


### PR DESCRIPTION
It allows to impersonate a different service account to verify quota issues. See b/336784945#comment12 for more details.

Bug: b/336784945