### PR TITLE
Add new types of rate limiters

### DIFF
--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -104,18 +104,18 @@ func TestMain(m *testing.M) {
 
 	// The default limit is 1500 per minute. Leave 200 buffer.
 	computeRL := cloud.NewTickerRateLimiter(1300, time.Minute)
-	crl.Register("", "HealthChecks", "", computeRL)
-	crl.Register("", "BackendServices", "", computeRL)
-	crl.Register("", "NetworkEndpointGroups", "", computeRL)
+	crl.Register("HealthChecks", "", computeRL)
+	crl.Register("BackendServices", "", computeRL)
+	crl.Register("NetworkEndpointGroups", "", computeRL)
 
 	// The default limit is 1200 per minute. Leave 200 buffer.
 	networkServicesRL := cloud.NewTickerRateLimiter(1000, time.Minute)
-	crl.Register("", "TcpRoutes", "", networkServicesRL)
-	crl.Register("", "Meshes", "", networkServicesRL)
+	crl.Register("TcpRoutes", "", networkServicesRL)
+	crl.Register("Meshes", "", networkServicesRL)
 
 	// To ensure minimum time between operations, wrap the network services rate limiter.
 	orl := &cloud.MinimumRateLimiter{RateLimiter: networkServicesRL, Minimum: 100 * time.Millisecond}
-	crl.Register("", "Operations", "", orl)
+	crl.Register("Operations", "", orl)
 
 	svc, err := cloud.NewService(ctx, client, &cloud.SingleProjectRouter{ID: testFlags.project}, crl)
 	if err != nil {

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -98,8 +98,26 @@ func TestMain(m *testing.M) {
 		}
 	}
 	client := oauth2.NewClient(ctx, ts)
+
 	mrl := &cloud.MinimumRateLimiter{RateLimiter: &cloud.NopRateLimiter{}, Minimum: 50 * time.Millisecond}
-	svc, err := cloud.NewService(ctx, client, &cloud.SingleProjectRouter{ID: testFlags.project}, mrl)
+	crl := cloud.NewCompositeRateLimiter(mrl)
+
+	// The default limit is 1500 per minute. Leave 200 buffer.
+	computeRL := cloud.NewTickerRateLimiter(1300, time.Minute)
+	crl.Register("", "HealthChecks", "", computeRL)
+	crl.Register("", "BackendServices", "", computeRL)
+	crl.Register("", "NetworkEndpointGroups", "", computeRL)
+
+	// The default limit is 1200 per minute. Leave 200 buffer.
+	networkServicesRL := cloud.NewTickerRateLimiter(1000, time.Minute)
+	crl.Register("", "TcpRoutes", "", networkServicesRL)
+	crl.Register("", "Meshes", "", networkServicesRL)
+
+	// To ensure minimum time between operations, wrap the network services rate limiter.
+	orl := &cloud.MinimumRateLimiter{RateLimiter: networkServicesRL, Minimum: 100 * time.Millisecond}
+	crl.Register("", "Operations", "", orl)
+
+	svc, err := cloud.NewService(ctx, client, &cloud.SingleProjectRouter{ID: testFlags.project}, crl)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/cloud/ratelimit.go
+++ b/pkg/cloud/ratelimit.go
@@ -100,10 +100,12 @@ type MinimumRateLimiter struct {
 // Accept blocks on the minimum duration and context. Once the minimum duration is met,
 // the func is blocked on the underlying ratelimiter.
 func (m *MinimumRateLimiter) Accept(ctx context.Context, key *RateLimitKey) error {
+	t := time.NewTimer(m.Minimum)
 	select {
-	case <-time.After(m.Minimum):
+	case <-t.C:
 		return m.RateLimiter.Accept(ctx, key)
 	case <-ctx.Done():
+		t.Stop()
 		return ctx.Err()
 	}
 }

--- a/pkg/cloud/ratelimit_test.go
+++ b/pkg/cloud/ratelimit_test.go
@@ -82,3 +82,33 @@ func TestMinimumRateLimiter(t *testing.T) {
 		t.Errorf("`called` = true, want false")
 	}
 }
+
+func TestTickerRateLimiter(t *testing.T) {
+	t.Parallel()
+
+	trl := NewTickerRateLimiter(100, time.Second)
+	start := time.Now()
+	for i := 0; i < 50; i++ {
+		err := trl.Accept(context.Background(), nil)
+		if err != nil {
+			t.Errorf("TickerRateLimiter.Accept = %v, want nil", err)
+		}
+	}
+	elapsed := time.Since(start)
+	if elapsed > time.Second {
+		t.Errorf("TickerRateLimiter.Accept took too long: %v, want <1s", elapsed)
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Errorf("TickerRateLimiter.Accept took too short: %v, want >500ms", elapsed)
+	}
+
+	// Use context that has been cancelled and expect a context error returned.
+	ctxCancelled, cancelled := context.WithCancel(context.Background())
+	cancelled()
+	// Verify context is cancelled by now.
+	<-ctxCancelled.Done()
+	err := trl.Accept(ctxCancelled, nil)
+	if err != ctxCancelled.Err() {
+		t.Errorf("TickerRateLimiter.Accept() = %v, want %v", err, ctxCancelled.Err())
+	}
+}


### PR DESCRIPTION
1. `TickerRateLimiter` is a simple implementation based on time.Ticker suggested in https://go.dev/wiki/RateLimiting. It works by spacing requests in predefined intervals. It doesn't allows bursts although it is fairly easy to add. A good candidate for replacement would be https://github.com/uber-go/ratelimit which supports "slack"
2. `CompositeRateLimiter` doesn't implement any rate limiting algorithm, but allows to combine all rate limiters (implementing the `RateLimiter` interface). A user can specify what rate limiter should be used for a specific combination of project, service and operation. An example usage is available in `e2e/testmain_test.go` where there are two `TickerRateLimiter`s used for `Compute` and `NetworkServices` API; and two `MinimumRateLimiter`s for `Operations` and as a fallback for all other requests

Bug: b/337197802