### PR TITLE
 Change type traits constrains logic.

### DIFF
--- a/pkg/cloud/api/check.go
+++ b/pkg/cloud/api/check.go
@@ -52,14 +52,14 @@ func checkPostAccess(traits *FieldTraits, v reflect.Value) error {
 				if !fv.IsZero() {
 					return false, fmt.Errorf("%s has a non-zero value (%v) but is an OutputOnly field", fv.Interface(), fp)
 				}
-			case FieldTypeOrdinary:
+			case FieldTypeNonZeroValue:
 				switch {
 				case fv.IsZero() && !acc.inNull(ft.Name) && !acc.inForceSend(ft.Name):
 					return false, fmt.Errorf("%s is zero value but not in a NullFields or ForceSendFields %v %t", fp, fv.Interface(), fv.IsZero())
 				case !fv.IsZero() && acc.inNull(ft.Name):
 					return false, fmt.Errorf("%s is non-nil and also in NullFields", fp)
 				}
-			case FieldTypeAllowZeroValue:
+			case FieldTypeOrdinary, FieldTypeAllowZeroValue:
 				continue
 			default:
 				return false, fmt.Errorf("invalid FieldType: %q", fType)

--- a/pkg/cloud/api/check_test.go
+++ b/pkg/cloud/api/check_test.go
@@ -40,12 +40,16 @@ func TestCheckFieldsAreSet(t *testing.T) {
 	}
 
 	ft := NewFieldTraits()
+	ft.NonZeroValue(Path{}.Pointer().Field("A"))
 
 	ftSystemField := ft.Clone()
-	ftSystemField.System(Path{}.Pointer().Field("A"))
+	ftSystemField.System(Path{}.Pointer().Field("B"))
 
 	ftOutputOnly := ft.Clone()
-	ftOutputOnly.OutputOnly(Path{}.Pointer().Field("A"))
+	ftOutputOnly.OutputOnly(Path{}.Pointer().Field("B"))
+
+	ftSubstruct := ft.Clone()
+	ftSubstruct.NonZeroValue(Path{}.Pointer().Field("S").Pointer().Field("A"))
 
 	for _, tc := range []struct {
 		name    string
@@ -93,7 +97,7 @@ func TestCheckFieldsAreSet(t *testing.T) {
 				B: 2,
 				S: &sti{},
 			},
-			ft:      ft,
+			ft:      ftSubstruct,
 			wantErr: true,
 		},
 		{
@@ -122,7 +126,7 @@ func TestCheckFieldsAreSet(t *testing.T) {
 				A:          1,
 				B:          2,
 				S:          &sti{A: 1},
-				NullFields: []string{"S"},
+				NullFields: []string{"A"},
 			},
 			ft:      ft,
 			wantErr: true},

--- a/pkg/cloud/api/fill.go
+++ b/pkg/cloud/api/fill.go
@@ -179,7 +179,7 @@ func fillNullAndForceSend(traits *FieldTraits, v reflect.Value) error {
 			fType := traits.fieldType(p.Field(ft.Name))
 			fv := v.Field(i)
 
-			if fType == FieldTypeOrdinary {
+			if fType == FieldTypeNonZeroValue {
 				switch {
 				case fv.IsZero() && fv.Type().Kind() == reflect.Pointer:
 					nullFields[ft.Name] = true

--- a/pkg/cloud/api/fill_test.go
+++ b/pkg/cloud/api/fill_test.go
@@ -103,6 +103,10 @@ func TestFill(t *testing.T) {
 
 func TestFillNullAndForceSend(t *testing.T) {
 	t.Parallel()
+	ft := NewFieldTraits()
+	ft.NonZeroValue(Path{}.Pointer().Field("A"))
+	ft.NonZeroValue(Path{}.Pointer().Field("B"))
+	ft.NonZeroValue(Path{}.Pointer().Field("D").Pointer().Field("A"))
 
 	type sti struct {
 		A               int
@@ -132,27 +136,26 @@ func TestFillNullAndForceSend(t *testing.T) {
 	}{
 		{
 			name: "fill with zero values",
-			ft:   NewFieldTraits(),
+			ft:   ft,
 			in:   &st{},
 			want: &st{
-				NullFields:      []string{"B", "D"},
-				ForceSendFields: []string{"A", "C"},
+				NullFields:      []string{"B"},
+				ForceSendFields: []string{"A"},
 			},
 		},
 		{
 			name: "fill no zeros",
-			ft:   NewFieldTraits(),
+			ft:   ft,
 			in:   &st{A: 5, B: new(string), C: "x", D: &sti{A: 2}},
 			want: &st{A: 5, B: new(string), C: "x", D: &sti{A: 2}},
 		},
 		{
 			name: "fill substruct",
-			ft:   NewFieldTraits(),
+			ft:   ft,
 			in:   &st{A: 5, D: &sti{}},
 			want: &st{
-				A:               5,
-				NullFields:      []string{"B"},
-				ForceSendFields: []string{"C"},
+				A:          5,
+				NullFields: []string{"B"},
 				D: &sti{
 					ForceSendFields: []string{"A"},
 				},
@@ -160,7 +163,7 @@ func TestFillNullAndForceSend(t *testing.T) {
 		},
 		{
 			name: "ignore .ServerResponse",
-			ft:   NewFieldTraits(),
+			ft:   ft,
 			in:   &stServerResponse{},
 			want: &stServerResponse{},
 		},

--- a/pkg/cloud/api/type_trait.go
+++ b/pkg/cloud/api/type_trait.go
@@ -138,8 +138,8 @@ type fieldTrait struct {
 type FieldType string
 
 const (
-	// FieldTypeOrdinary is a ordinary field. It must be set (non-zero or in a
-	// meta-field. It will be compared by value in a diff.
+	// FieldTypeOrdinary is a ordinary field. It will be compared by value in a
+	// diff. It can be zero-value without being in a metafield.
 	FieldTypeOrdinary FieldType = "Ordinary"
 	// FieldTypeSystem fields are internal infrastructure related fields. These are never
 	// copied or diff'd.
@@ -148,8 +148,13 @@ const (
 	// should never be set by the client.
 	FieldTypeOutputOnly FieldType = "OutputOnly"
 	// FieldTypeAllowZeroValue is an ordinary field that can be zero-value
-	// without being in a metafield. This is used for testing.
+	// without being in a metafield. This is used for testing. TODO(kl52752)
+	// remove this field when all resources are migrating to
+	// FieldTypeNonZeroValue.
 	FieldTypeAllowZeroValue FieldType = "AllowZeroValue"
+	// FieldTypeNonZeroValue is a field that's value must be non-zero or
+	// specified in a meta-field. It will be compared by value in a diff.
+	FieldTypeNonZeroValue FieldType = "NonZeroValue"
 )
 
 // CheckSchema validates that the traits are valid and match the schema of the
@@ -179,6 +184,9 @@ func (dt *FieldTraits) System(p Path) { dt.add(p, FieldTypeSystem) }
 
 // AllowZeroValue specifies the type of the given path.
 func (dt *FieldTraits) AllowZeroValue(p Path) { dt.add(p, FieldTypeAllowZeroValue) }
+
+// NonZeroValue specifies the type of the given path.
+func (dt *FieldTraits) NonZeroValue(p Path) { dt.add(p, FieldTypeNonZeroValue) }
 
 // Clone create an exact copy of the traits.
 func (dt *FieldTraits) Clone() *FieldTraits {

--- a/pkg/cloud/rgraph/rnode/backendservice/backendservice_test.go
+++ b/pkg/cloud/rgraph/rnode/backendservice/backendservice_test.go
@@ -22,8 +22,12 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/api"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/exec"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/rgraph/rnode/fake"
+	"github.com/google/go-cmp/cmp"
 	alpha "google.golang.org/api/compute/v0.alpha"
 	beta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
@@ -71,56 +75,147 @@ func createBackendServiceNode(name string, setFun func(x MutableBackendService) 
 	return gotNode, nil
 }
 
+func createBackendServiceResource(t *testing.T, bsID *cloud.ResourceID, modifyFun func(x MutableBackendService) error) rnode.UntypedResource {
+	bsMutResource := NewMutableBackendService(proj, bsID.Key)
+	err := bsMutResource.Access(func(x *compute.BackendService) {
+		x.LoadBalancingScheme = "INTERNAL_SELF_MANAGED"
+		x.Protocol = "TCP"
+		x.Port = 80
+		x.CompressionMode = "DISABLED"
+		x.ConnectionDraining = &compute.ConnectionDraining{}
+		x.SessionAffinity = "NONE"
+		x.TimeoutSec = 30
+	})
+	if err != nil {
+		t.Fatalf("setFun(_) = %v, want nil", err)
+	}
+	if modifyFun != nil {
+		modifyFun(bsMutResource)
+	}
+	bsResource, err := bsMutResource.Freeze()
+	if err != nil {
+		t.Fatalf("bsMutResource.Freeze() = %v, want nil", err)
+	}
+	return bsResource
+}
+
 func TestActionUpdate(t *testing.T) {
-	setUpResource := func(m MutableBackendService) error {
-		return m.Access(func(x *compute.BackendService) {
-			x.LoadBalancingScheme = "INTERNAL_SELF_MANAGED"
-			x.Protocol = "TCP"
-			x.Port = 80
-			x.HealthChecks = []string{hcSelfLink}
-			x.CompressionMode = "DISABLED"
-			x.ConnectionDraining = &compute.ConnectionDraining{}
-			x.SessionAffinity = "NONE"
-			x.TimeoutSec = 30
+	for _, tc := range []struct {
+		desc           string
+		setUpFn        func(m MutableBackendService) error
+		wantGAError    bool
+		wantAlphaError bool
+		wantBetaError  bool
+	}{
+		{
+			desc: "ga",
+			setUpFn: func(m MutableBackendService) error {
+				return m.Access(func(x *compute.BackendService) {
+					x.LoadBalancingScheme = "INTERNAL_SELF_MANAGED"
+					x.Protocol = "TCP"
+					x.Port = 80
+					x.HealthChecks = []string{hcSelfLink}
+					x.CompressionMode = "DISABLED"
+					x.ConnectionDraining = &compute.ConnectionDraining{}
+					x.SessionAffinity = "NONE"
+					x.TimeoutSec = 30
+				})
+			},
+		},
+		{
+			desc: "alpha",
+			setUpFn: func(m MutableBackendService) error {
+				return m.AccessAlpha(func(x *alpha.BackendService) {
+					x.LoadBalancingScheme = "INTERNAL_SELF_MANAGED"
+					x.Protocol = "TCP"
+					x.Port = 80
+					x.HealthChecks = []string{hcSelfLink}
+					x.ConnectionDraining = &alpha.ConnectionDraining{}
+					x.CompressionMode = "DISABLED"
+					x.Network = "default"
+					x.SessionAffinity = "NONE"
+					x.TimeoutSec = 30
+					x.IpAddressSelectionPolicy = "NONE"
+					x.VpcNetworkScope = "IPV6"
+					x.ExternalManagedMigrationState = "TEST"
+					x.SecuritySettings = &alpha.SecuritySettings{
+						Authentication:  "abcd",
+						SubjectAltNames: []string{"name"},
+					}
+				})
+			},
+			wantGAError:   true,
+			wantBetaError: true,
+		},
+		{
+			desc: "beta",
+			setUpFn: func(m MutableBackendService) error {
+				return m.AccessBeta(func(x *beta.BackendService) {
+					x.LoadBalancingScheme = "INTERNAL_SELF_MANAGED"
+					x.Protocol = "TCP"
+					x.Port = 80
+					x.HealthChecks = []string{hcSelfLink}
+					x.ConnectionDraining = &beta.ConnectionDraining{}
+					x.CompressionMode = "DISABLED"
+					x.Network = "default"
+					x.SessionAffinity = "NONE"
+					x.TimeoutSec = 30
+					x.IpAddressSelectionPolicy = "NONE"
+				})
+			},
+			wantGAError: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+
+			gotNode, err := createBackendServiceNode("bs-name", tc.setUpFn)
+			if err != nil {
+				t.Fatalf("createBackendServiceNode(bs-name, _) = %v, want nil", err)
+			}
+			gotBs := gotNode.Resource().(BackendService)
+
+			_, gaErr := gotBs.ToGA()
+			gotGAError := gaErr != nil
+			if gotGAError != tc.wantGAError {
+				t.Errorf("gotBs.ToGA() = %v, got %v want %v", gaErr, gotGAError, tc.wantGAError)
+			}
+			_, alphaErr := gotBs.ToAlpha()
+			gotAlphaError := alphaErr != nil
+			if gotAlphaError != tc.wantAlphaError {
+				t.Errorf("gotBs.ToAlpha() = %v, got %v want %v", alphaErr, gotAlphaError, tc.wantAlphaError)
+			}
+			_, betaErr := gotBs.ToBeta()
+			gotBetaError := betaErr != nil
+			if gotBetaError != tc.wantBetaError {
+				t.Errorf("gotBs.ToBeta() = %v, got %v want %v", betaErr, gotBetaError, tc.wantBetaError)
+			}
+
+			fingerprint, err := fingerprint(gotNode)
+			if err != nil {
+				t.Fatalf("fingerprint(_) = %v, want nil", err)
+			}
+			actions, err := rnode.UpdateActions[compute.BackendService, alpha.BackendService, beta.BackendService](&ops{}, gotNode, gotNode, gotNode.resource, fingerprint)
+			if err != nil {
+				t.Fatalf("rnode.UpdateActions[]() = %v, want nil", err)
+			}
+			if len(actions) == 0 {
+				t.Fatalf("no actions to update")
+			}
+			a := actions[0]
+			mockCloud := cloud.NewMockGCE(&cloud.SingleProjectRouter{ID: proj})
+			updateHook := func(ctx context.Context, key *meta.Key, bs *compute.BackendService, m *cloud.MockBackendServices, o ...cloud.Option) error {
+				if bs.Fingerprint != fingerprint {
+					t.Fatalf("Update BackendService Hook: fingerprint mismatch got: %s, want %s", bs.Fingerprint, fingerprint)
+				}
+				return nil
+			}
+			mockCloud.MockBackendServices.UpdateHook = updateHook
+			_, err = a.Run(context.Background(), mockCloud)
+			if err != nil {
+				t.Fatalf("a.Run(_, mockCloud) = %v, want nil", err)
+			}
 		})
 	}
-
-	gotNode, err := createBackendServiceNode("bs-name", setUpResource)
-	if err != nil {
-		t.Fatalf("createBackendServiceNode(bs-name, _) = %v, want nil", err)
-	}
-	gotBs := gotNode.Resource().(BackendService)
-
-	_, err = gotBs.ToGA()
-	if err != nil {
-		t.Errorf("gotBs.ToGA() = %v, want nil", err)
-	}
-
-	fingerprint, err := fingerprint(gotNode)
-	if err != nil {
-		t.Fatalf("fingerprint(_) = %v, want nil", err)
-	}
-	actions, err := rnode.UpdateActions[compute.BackendService, alpha.BackendService, beta.BackendService](&ops{}, gotNode, gotNode, gotNode.resource, fingerprint)
-	if err != nil {
-		t.Fatalf("rnode.UpdateActions[]() = %v, want nil", err)
-	}
-	if len(actions) == 0 {
-		t.Fatalf("no actions to update")
-	}
-	a := actions[0]
-	mockCloud := cloud.NewMockGCE(&cloud.SingleProjectRouter{ID: proj})
-	updateHook := func(ctx context.Context, key *meta.Key, bs *compute.BackendService, m *cloud.MockBackendServices, o ...cloud.Option) error {
-		if bs.Fingerprint != fingerprint {
-			t.Fatalf("Update BackendService Hook: fingerprint mismatch got: %s, want %s", bs.Fingerprint, fingerprint)
-		}
-		return nil
-	}
-	mockCloud.MockBackendServices.UpdateHook = updateHook
-	_, err = a.Run(context.Background(), mockCloud)
-	if err != nil {
-		t.Fatalf("a.Run(_, mockCloud) = %v, want nil", err)
-	}
-
 }
 
 func TestBackendServiceDiff(t *testing.T) {
@@ -591,6 +686,86 @@ func TestBackendServiceDiff(t *testing.T) {
 	}
 }
 
+func TestBackendServiceDiffError(t *testing.T) {
+	bsName := "bs-name"
+	setUpFn := func(m MutableBackendService) error {
+		return m.Access(func(x *compute.BackendService) {
+			x.LoadBalancingScheme = "INTERNAL_SELF_MANAGED"
+			x.Protocol = "TCP"
+			x.Port = 100
+			x.HealthChecks = []string{hcSelfLink}
+			x.ConnectionDraining = &compute.ConnectionDraining{}
+			x.CompressionMode = "DISABLED"
+			x.Network = "default"
+			x.SessionAffinity = "NONE"
+			x.TimeoutSec = 30
+		})
+	}
+	bsNode, err := createBackendServiceNode(bsName, setUpFn)
+	if err != nil {
+		t.Fatalf("createBackendServiceNode(%s, _) = %v, want nil", bsName, err)
+	}
+	fakeId := ID(proj, meta.GlobalKey(bsName))
+	fakeBuilder := fake.NewBuilder(fakeId)
+	fakeRes := fake.NewMutableFake(proj, fakeId.Key)
+	res, err := fakeRes.Freeze()
+	fakeBuilder.SetResource(res)
+	fakeNode, err := fakeBuilder.Build()
+
+	_, err = bsNode.Diff(fakeNode)
+	if err == nil {
+		t.Fatal("wantNode.Diff(fakeNode) = nil, want error")
+	}
+}
+
+func TestGAFields(t *testing.T) {
+	bsID := ID(proj, meta.GlobalKey("bs-test"))
+	bsMutResource := NewMutableBackendService(proj, bsID.Key)
+	err := bsMutResource.Access(func(x *compute.BackendService) {
+		x.HealthChecks = []string{hcSelfLink}
+		x.Network = "default"
+		x.SessionAffinity = "NONE"
+		x.TimeoutSec = 3
+	})
+	// expect error no all required fields are set
+	if err == nil {
+		t.Fatal("bsMutResource.Access(_) = nil, want error")
+	}
+	err = bsMutResource.Access(func(x *compute.BackendService) {
+		x.Protocol = "TCP"
+		x.Port = 80
+		x.LoadBalancingScheme = "INTERNAL_SELF_MANAGED"
+		x.ConnectionDraining = &compute.ConnectionDraining{}
+		x.CompressionMode = "DISABLED"
+	})
+	if err != nil {
+		t.Fatalf("bsMutResource.Access(_) = %v, want nil", err)
+	}
+	// Check that Output Only field should not be set
+	err = bsMutResource.Access(func(x *compute.BackendService) {
+		x.Kind = "some kind"
+	})
+	if err == nil {
+		t.Fatalf("bsMutResource.Access(_) = %v, want nil", err)
+	}
+	err = bsMutResource.Access(func(x *compute.BackendService) {
+		x.Kind = ""
+		x.Fingerprint = fingerprintStr
+	})
+	bsResource, err := bsMutResource.Freeze()
+	if err != nil {
+		t.Fatalf("bsMutResource.Freeze() = %v, want nil", err)
+	}
+	bsBuilder := NewBuilderWithResource(bsResource)
+	_, err = bsBuilder.Build()
+	if err != nil {
+		t.Fatalf("bsBuilder.Build() = %v, want nil", err)
+	}
+	outRefs, err := bsBuilder.OutRefs()
+	if len(outRefs) == 0 {
+		t.Fatalf("Out refs length mismatch got:%v, want: >0 ", len(outRefs))
+	}
+}
 func TestAlphaFields(t *testing.T) {
 	bsID := ID(proj, meta.GlobalKey("bs-test"))
 	bsMutResource := NewMutableBackendService(proj, bsID.Key)
@@ -717,5 +892,256 @@ func TestBetaFields(t *testing.T) {
 	}
 	if gotFingerprint != fingerprintStr {
 		t.Fatalf("Fingerprint mismatch got: %s want: %s", gotFingerprint, fingerprintStr)
+	}
+}
+
+func TestBackendServiceActions(t *testing.T) {
+	setUpResource := func(m MutableBackendService) error {
+		return m.Access(func(x *compute.BackendService) {
+			x.LoadBalancingScheme = "INTERNAL_SELF_MANAGED"
+			x.Protocol = "TCP"
+			x.Port = 80
+			x.HealthChecks = []string{hcSelfLink}
+			x.CompressionMode = "DISABLED"
+			x.ConnectionDraining = &compute.ConnectionDraining{}
+			x.SessionAffinity = "NONE"
+			x.TimeoutSec = 30
+		})
+	}
+
+	n1, err := createBackendServiceNode("bs-name", setUpResource)
+	if err != nil {
+		t.Fatalf("createBackendServiceNode(bs-name, _) = %v, want nil", err)
+	}
+
+	for _, tc := range []struct {
+		desc    string
+		op      rnode.Operation
+		wantErr bool
+		want    []exec.ActionType
+	}{
+		{
+			desc: "create action",
+			op:   rnode.OpCreate,
+			want: []exec.ActionType{exec.ActionTypeCreate},
+		},
+		{
+			desc: "delete action",
+			op:   rnode.OpDelete,
+			want: []exec.ActionType{exec.ActionTypeDelete},
+		},
+		{
+			desc: "recreate action",
+			op:   rnode.OpRecreate,
+			want: []exec.ActionType{exec.ActionTypeDelete, exec.ActionTypeCreate},
+		},
+		{
+			desc: "no action",
+			op:   rnode.OpNothing,
+			want: []exec.ActionType{exec.ActionTypeMeta},
+		},
+		{
+			desc: "update action",
+			op:   rnode.OpUpdate,
+			want: []exec.ActionType{exec.ActionTypeUpdate},
+		},
+		{
+			desc:    "default",
+			op:      rnode.OpUnknown,
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			b := n1.Builder()
+			b.SetResource(n1.resource)
+			n2, err := b.Build()
+			if err != nil {
+				t.Fatalf("b.Build() = %v, want nil", err)
+			}
+
+			n1.Plan().Set(rnode.PlanDetails{
+				Operation: tc.op,
+				Why:       "test plan",
+			})
+			actions, err := n1.Actions(n2)
+			isError := (err != nil)
+			if tc.wantErr != isError {
+				t.Fatalf("n.Actions(_) =%v got error %v, want %v", err, tc.wantErr, isError)
+			}
+			if tc.wantErr {
+				return
+			}
+			if err != nil {
+				t.Fatalf("n.Actions(_) = %v, want nil", err)
+			}
+			if len(actions) != len(tc.want) {
+				t.Fatalf("n.Actions(%q) returned list with elements %d want %d", tc.op, len(actions), len(tc.want))
+			}
+			for i, a := range actions {
+				if a.Metadata().Type != tc.want[i] {
+					t.Errorf("Actions mismatch: got: %s, want: %s", a.Metadata().Name, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestOutRefs(t *testing.T) {
+	bsID := ID(proj, meta.GlobalKey("bs-test"))
+	hcID := &cloud.ResourceID{
+		Resource:  "healthChecks",
+		APIGroup:  meta.APIGroupCompute,
+		ProjectID: proj,
+		Key:       meta.GlobalKey("hc-name"),
+	}
+	negID := &cloud.ResourceID{
+		Resource:  "networkEndpointGroups",
+		APIGroup:  meta.APIGroupCompute,
+		ProjectID: proj,
+		Key:       meta.GlobalKey("hc-name"),
+	}
+	espID := &cloud.ResourceID{
+		Resource:  "edgeSecurityPolicy",
+		APIGroup:  meta.APIGroupCompute,
+		ProjectID: proj,
+		Key:       meta.GlobalKey("esp-name"),
+	}
+	spID := &cloud.ResourceID{
+		Resource:  "ecurityPolicy",
+		APIGroup:  meta.APIGroupCompute,
+		ProjectID: proj,
+		Key:       meta.GlobalKey("esp-name"),
+	}
+	for _, tc := range []struct {
+		desc        string
+		resource    rnode.UntypedResource
+		wantErr     bool
+		wantOutRefs []rnode.ResourceRef
+	}{
+		{
+			desc: "nil",
+		},
+		{
+			desc:     "without OutRefs",
+			resource: createBackendServiceResource(t, bsID, nil),
+		},
+		{
+			desc: "with health check",
+			resource: createBackendServiceResource(t, bsID, func(m MutableBackendService) error {
+				return m.Access(func(x *compute.BackendService) {
+					x.HealthChecks = []string{hcID.SelfLink(meta.VersionGA)}
+				})
+			}),
+			wantOutRefs: []rnode.ResourceRef{
+				{
+					From: bsID,
+					Path: api.Path{}.Field("HealthChecks").Index(0),
+					To:   hcID,
+				},
+			},
+		},
+		{
+			desc: "with health check wrong format",
+			resource: createBackendServiceResource(t, bsID, func(m MutableBackendService) error {
+				return m.Access(func(x *compute.BackendService) {
+					x.HealthChecks = []string{"https://apigroup.googleapis.com/alpha/projects/proj1/global/healthchecks/hcname"}
+				})
+			}),
+			wantErr: true,
+		},
+		{
+			desc: "with backends",
+			resource: createBackendServiceResource(t, bsID, func(m MutableBackendService) error {
+				return m.Access(func(x *compute.BackendService) {
+					x.Backends = []*compute.Backend{
+						{Group: negID.SelfLink(meta.VersionGA)},
+					}
+				})
+			}),
+			wantOutRefs: []rnode.ResourceRef{
+				{
+					From: bsID,
+					Path: api.Path{}.Field("Backends").Index(0).Field("Group"),
+					To:   negID,
+				},
+			},
+		},
+		{
+			desc: "with health check wrong format",
+			resource: createBackendServiceResource(t, bsID, func(m MutableBackendService) error {
+				return m.Access(func(x *compute.BackendService) {
+					x.Backends = []*compute.Backend{
+						{Group: "https://apigroup.googleapis.com/alpha/projects/proj1/global/negs/negname"},
+					}
+				})
+			}),
+			wantErr: true,
+		},
+		{
+			desc: "with  securityPolicy",
+			resource: createBackendServiceResource(t, bsID, func(m MutableBackendService) error {
+				return m.Access(func(x *compute.BackendService) {
+					x.SecurityPolicy = spID.SelfLink(meta.VersionGA)
+				})
+			}),
+			wantOutRefs: []rnode.ResourceRef{
+				{
+					From: bsID,
+					Path: api.Path{}.Field("SecurityPolicy"),
+					To:   spID,
+				},
+			},
+		},
+		{
+			desc: "with securityPolicy wrong format",
+			resource: createBackendServiceResource(t, bsID, func(m MutableBackendService) error {
+				return m.Access(func(x *compute.BackendService) {
+					x.SecurityPolicy = "https://apigroup.googleapis.com/alpha/projects/proj1/global/negs/negname"
+				})
+			}),
+			wantErr: true,
+		},
+		{
+			desc: "with edge securityPolicy",
+			resource: createBackendServiceResource(t, bsID, func(m MutableBackendService) error {
+				return m.Access(func(x *compute.BackendService) {
+					x.EdgeSecurityPolicy = espID.SelfLink(meta.VersionGA)
+				})
+			}),
+			wantOutRefs: []rnode.ResourceRef{
+				{
+					From: bsID,
+					Path: api.Path{}.Field("EdgeSecurityPolicy"),
+					To:   espID,
+				},
+			},
+		},
+		{
+			desc: "with edge securityPolicy wrong format",
+			resource: createBackendServiceResource(t, bsID, func(m MutableBackendService) error {
+				return m.Access(func(x *compute.BackendService) {
+					x.EdgeSecurityPolicy = "https://apigroup.googleapis.com/alpha/projects/proj1/global/negs/negname"
+				})
+			}),
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			bsBuilder := NewBuilder(bsID)
+			bsBuilder.SetResource(tc.resource)
+			bsBuilder.Build()
+			outRefs, err := bsBuilder.OutRefs()
+			gotErr := err != nil
+			if tc.wantErr != gotErr {
+				t.Fatalf("bsBuilder.OutRefs() = %v want error %v, got %v", err, tc.wantErr, gotErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if diff := cmp.Diff(outRefs, tc.wantOutRefs); diff != "" {
+				t.Fatalf("Out refs mismatch: %s ", diff)
+
+			}
+		})
 	}
 }

--- a/pkg/cloud/rgraph/rnode/backendservice/builder.go
+++ b/pkg/cloud/rgraph/rnode/backendservice/builder.go
@@ -120,7 +120,7 @@ func (b *builder) OutRefs() ([]rnode.ResourceRef, error) {
 		}
 		ret = append(ret, rnode.ResourceRef{
 			From: b.ID(),
-			Path: api.Path{}.Field("SecurityPolicy"),
+			Path: api.Path{}.Field("EdgeSecurityPolicy"),
 			To:   id,
 		})
 	}

--- a/pkg/cloud/rgraph/rnode/backendservice/type_trait.go
+++ b/pkg/cloud/rgraph/rnode/backendservice/type_trait.go
@@ -49,8 +49,6 @@ func (*typeTrait) FieldTraits(v meta.Version) *api.FieldTraits {
 
 	dt.NonZeroValue(api.Path{}.Pointer().Field("LoadBalancingScheme"))
 	dt.NonZeroValue(api.Path{}.Pointer().Field("Protocol"))
-	dt.NonZeroValue(api.Path{}.Pointer().Field("Port"))
-	dt.NonZeroValue(api.Path{}.Pointer().Field("HealthChecks"))
 	dt.NonZeroValue(api.Path{}.Pointer().Field("CompressionMode"))
 	// TODO(kl52752) change this field to mandatory after fixing type traits check.
 	// Type traits check should be per path and not inherited from parent.

--- a/pkg/cloud/rgraph/rnode/backendservice/type_trait.go
+++ b/pkg/cloud/rgraph/rnode/backendservice/type_trait.go
@@ -43,136 +43,32 @@ func (*typeTrait) FieldTraits(v meta.Version) *api.FieldTraits {
 	dt.OutputOnly(api.Path{}.Pointer().Field("SecurityPolicy"))
 	dt.OutputOnly(api.Path{}.Pointer().Field("SelfLink"))
 
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Iap"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Iap").Pointer().Field("Enabled"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Iap").Pointer().Field("Oauth2ClientId"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Iap").Pointer().Field("Oauth2ClientSecret"))
 	dt.OutputOnly(api.Path{}.Pointer().Field("Iap").Pointer().Field("Oauth2ClientSecretSha256"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Port"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("PortName"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ServiceBindings"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ServiceLbPolicy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Subsetting"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("UsedBy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Network"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy"))
 	dt.OutputOnly(api.Path{}.Pointer().Field("CdnPolicy").Field("SignedUrlKeyNames"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("BypassCacheOnRequestHeaders"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("BypassCacheOnRequestHeaders").AnySliceIndex().Pointer().Field("HeaderName"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("IncludeHost"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("IncludeHttpHeaders"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("IncludeNamedCookies"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("IncludeProtocol"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("IncludeQueryString"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("QueryStringBlacklist"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("QueryStringWhitelist"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("DefaultTtl"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("MaxTtl"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("NegativeCachingPolicy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("NegativeCachingPolicy").AnySliceIndex().Pointer().Field("Ttl"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("RequestCoalescing"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("ServeWhileStale"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("SignedUrlCacheMaxAgeSec"))
 	dt.OutputOnly(api.Path{}.Pointer().Field("CdnPolicy").Pointer().Field("CacheKeyPolicy").Pointer().Field("SignedUrlKeyNames"))
 
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CircuitBreakers"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CircuitBreakers").Pointer().Field("MaxConnections"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CircuitBreakers").Pointer().Field("MaxPendingRequests"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CircuitBreakers").Pointer().Field("MaxRequests"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CircuitBreakers").Pointer().Field("MaxRequestsPerConnection"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CircuitBreakers").Pointer().Field("MaxRetries"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("LoadBalancingScheme"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("Protocol"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("Port"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("HealthChecks"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("CompressionMode"))
+	// TODO(kl52752) change this field to mandatory after fixing type traits check.
+	// Type traits check should be per path and not inherited from parent.
+	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConnectionDraining"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("SessionAffinity"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("TimeoutSec"))
 
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConnectionDraining").Pointer().Field("DrainingTimeoutSec"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConnectionTrackingPolicy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConnectionTrackingPolicy").Pointer().Field("EnableStrongAffinity"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConsistentHash"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConsistentHash").Pointer().Field("HttpCookie"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConsistentHash").Pointer().Field("HttpCookie").Pointer().Field("Path"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConsistentHash").Pointer().Field("HttpCookie").Pointer().Field("Ttl"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConsistentHash").Pointer().Field("HttpCookie").Pointer().Field("Ttl").Pointer().Field("Nanos"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConsistentHash").Pointer().Field("HttpCookie").Pointer().Field("Ttl").Pointer().Field("Seconds"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConsistentHash").Pointer().Field("HttpHeaderName"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CustomRequestHeaders"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Description"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("EnableCDN"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("FailoverPolicy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("FailoverPolicy").Pointer().Field("DisableConnectionDrainOnFailover"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("FailoverPolicy").Pointer().Field("DropTrafficIfUnhealthy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("FailoverPolicy").Pointer().Field("FailoverRatio"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("HealthChecks"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("CustomResponseHeaders"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("AffinityCookieTtlSec"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends").AnySliceIndex().Pointer().Field("CapacityScaler"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends").AnySliceIndex().Pointer().Field("Failover"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends").AnySliceIndex().Pointer().Field("MaxConnections"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends").AnySliceIndex().Pointer().Field("MaxConnectionsPerEndpoint"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends").AnySliceIndex().Pointer().Field("MaxConnectionsPerInstance"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends").AnySliceIndex().Pointer().Field("MaxRate"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends").AnySliceIndex().Pointer().Field("MaxRatePerEndpoint"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends").AnySliceIndex().Pointer().Field("MaxRatePerInstance"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Backends").AnySliceIndex().Pointer().Field("MaxUtilization"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LocalityLbPolicies"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LocalityLbPolicies").AnySliceIndex().Pointer().Field("CustomPolicy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LocalityLbPolicies").AnySliceIndex().Pointer().Field("CustomPolicy").Pointer().Field("Data"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LocalityLbPolicies").AnySliceIndex().Pointer().Field("Policy"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LocalityLbPolicy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LogConfig"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LogConfig").Pointer().Field("Enable"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LogConfig").Pointer().Field("OptionalFields"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LogConfig").Pointer().Field("SampleRate"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("MaxStreamDuration"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("MaxStreamDuration").Pointer().Field("Nanos"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("MaxStreamDuration").Pointer().Field("Seconds"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Metadatas"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("OutlierDetection"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("OutlierDetection").Pointer().Field("EnforcingConsecutiveErrors"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("AwsV4Authentication"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("AwsV4Authentication").Pointer().Field("AccessKeyId"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("AwsV4Authentication").Pointer().Field("AccessKeyVersion"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("ClientTlsPolicy"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("SubjectAltNames"))
-
-	if v == meta.VersionBeta || v == meta.VersionAlpha {
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("Authentication"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("CircuitBreakers").Pointer().Field("ConnectTimeout"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("CircuitBreakers").Pointer().Field("ConnectTimeout").Pointer().Field("Nanos"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("CircuitBreakers").Pointer().Field("ConnectTimeout").Pointer().Field("Seconds"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("Subsetting").Pointer().Field("SubsetSize"))
-
+	if v == meta.VersionBeta {
+		dt.NonZeroValue(api.Path{}.Pointer().Field("IpAddressSelectionPolicy"))
 	}
 	if v == meta.VersionAlpha {
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("AuthenticationPolicy"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("AuthorizationConfig"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("ClientTlsSettings"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("ClientTlsSettings").Pointer().Field("ClientTlsContext"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("ClientTlsSettings").Pointer().Field("Sni"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("ClientTlsSettings").Pointer().Field("SubjectAltNames"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("SecuritySettings").Pointer().Field("SubjectAltNames"))
-
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("ExternalManagedMigrationTestingRate"))
 		dt.OutputOnly(api.Path{}.Pointer().Field("SelfLinkWithId"))
 
 		// not supported
 		dt.OutputOnly(api.Path{}.Pointer().Field("HaPolicy"))
 
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("Iap").Pointer().Field("Oauth2ClientInfo"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("Iap").Pointer().Field("Oauth2ClientInfo").Pointer().Field("ApplicationName"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("Iap").Pointer().Field("Oauth2ClientInfo").Pointer().Field("ClientName"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("Iap").Pointer().Field("Oauth2ClientInfo").Pointer().Field("DeveloperEmailAddress"))
+		dt.NonZeroValue(api.Path{}.Pointer().Field("VpcNetworkScope"))
+		dt.NonZeroValue(api.Path{}.Pointer().Field("ExternalManagedMigrationState"))
 	}
 	return dt
 }

--- a/pkg/cloud/rgraph/rnode/healthcheck/type_trait.go
+++ b/pkg/cloud/rgraph/rnode/healthcheck/type_trait.go
@@ -38,47 +38,23 @@ func (*typeTrait) FieldTraits(v meta.Version) *api.FieldTraits {
 	dt.OutputOnly(api.Path{}.Pointer().Field("Region"))
 	dt.OutputOnly(api.Path{}.Pointer().Field("SelfLink"))
 
-	// Optional fields
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Description"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("LogConfig"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("GrpcHealthCheck"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("GrpcHealthCheck").Pointer().Field("GrpcServiceName"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("GrpcHealthCheck").Pointer().Field("Port"))
 	// This field is not supported
 	dt.OutputOnly(api.Path{}.Pointer().Field("GrpcHealthCheck").Pointer().Field("PortName"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Http2HealthCheck"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("Http2HealthCheck").Pointer().Field("Response"))
-	// This field is not supported
 	dt.OutputOnly(api.Path{}.Pointer().Field("Http2HealthCheck").Pointer().Field("PortName"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("HttpHealthCheck"))
-	// This field is not supported
 	dt.OutputOnly(api.Path{}.Pointer().Field("HttpHealthCheck").Pointer().Field("PortName"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("HttpHealthCheck").Pointer().Field("Response"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("HttpsHealthCheck"))
-	// This field is not supported
-	dt.OutputOnly(api.Path{}.Pointer().Field("HttpsHealthCheck").Pointer().Field("PortName"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("HttpsHealthCheck").Pointer().Field("Response"))
-
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("SslHealthCheck"))
-	// This field is not supported
 	dt.OutputOnly(api.Path{}.Pointer().Field("SslHealthCheck").Pointer().Field("PortName"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("SslHealthCheck").Pointer().Field("Request"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("SslHealthCheck").Pointer().Field("Response"))
+	dt.OutputOnly(api.Path{}.Pointer().Field("HttpsHealthCheck").Pointer().Field("PortName"))
 
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("TcpHealthCheck"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("TcpHealthCheck").Pointer().Field("Request"))
-	dt.AllowZeroValue(api.Path{}.Pointer().Field("TcpHealthCheck").Pointer().Field("Response"))
+	// required fields
+	dt.NonZeroValue(api.Path{}.Pointer().Field("HealthyThreshold"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("UnhealthyThreshold"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("CheckIntervalSec"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("TimeoutSec"))
+	dt.NonZeroValue(api.Path{}.Pointer().Field("Type"))
 
 	if v == meta.VersionAlpha {
 		dt.OutputOnly(api.Path{}.Pointer().Field("SelfLinkWithId"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("SourceRegions"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("UdpHealthCheck"))
 		dt.OutputOnly(api.Path{}.Pointer().Field("UdpHealthCheck").Pointer().Field("PortName"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("UdpHealthCheck").Pointer().Field("Request"))
-		dt.AllowZeroValue(api.Path{}.Pointer().Field("UdpHealthCheck").Pointer().Field("Response"))
 	}
 
 	return dt


### PR DESCRIPTION
Loosen up default type traits constraint logic that requires the field to be set.

This PR has multiple changes:
1. Introducing new type trait FieldTypeMandatory.
2. Change default type FieldTypeOrdinary to allow zero value.
After changes in type traits code coverage for health check and backend service fell below 80% so in 2 separate commits tests for given components were added. 