### PR TITLE
Remove latency measurements from TickerRateLimiter tests

### DIFF
--- a/pkg/cloud/ratelimit_test.go
+++ b/pkg/cloud/ratelimit_test.go
@@ -98,8 +98,10 @@ func TestTickerRateLimiter(t *testing.T) {
 	if elapsed > time.Second {
 		t.Errorf("TickerRateLimiter.Accept took too long: %v, want <1s", elapsed)
 	}
-	if elapsed < 500*time.Millisecond {
-		t.Errorf("TickerRateLimiter.Accept took too short: %v, want >500ms", elapsed)
+	// The first Accept call doesn't wait for the whole duration between
+	// ticks (it is possible it will return immediately).
+	if elapsed < 490*time.Millisecond {
+		t.Errorf("TickerRateLimiter.Accept took too short: %v, want >490ms", elapsed)
 	}
 
 	// Use context that has been cancelled and expect a context error returned.

--- a/pkg/cloud/ratelimit_test.go
+++ b/pkg/cloud/ratelimit_test.go
@@ -87,21 +87,9 @@ func TestTickerRateLimiter(t *testing.T) {
 	t.Parallel()
 
 	trl := NewTickerRateLimiter(100, time.Second)
-	start := time.Now()
-	for i := 0; i < 50; i++ {
-		err := trl.Accept(context.Background(), nil)
-		if err != nil {
-			t.Errorf("TickerRateLimiter.Accept = %v, want nil", err)
-		}
-	}
-	elapsed := time.Since(start)
-	if elapsed > time.Second {
-		t.Errorf("TickerRateLimiter.Accept took too long: %v, want <1s", elapsed)
-	}
-	// The first Accept call doesn't wait for the whole duration between
-	// ticks (it is possible it will return immediately).
-	if elapsed < 490*time.Millisecond {
-		t.Errorf("TickerRateLimiter.Accept took too short: %v, want >490ms", elapsed)
+	err := trl.Accept(context.Background(), nil)
+	if err != nil {
+		t.Errorf("TickerRateLimiter.Accept = %v, want nil", err)
 	}
 
 	// Use context that has been cancelled and expect a context error returned.
@@ -109,7 +97,7 @@ func TestTickerRateLimiter(t *testing.T) {
 	cancelled()
 	// Verify context is cancelled by now.
 	<-ctxCancelled.Done()
-	err := trl.Accept(ctxCancelled, nil)
+	err = trl.Accept(ctxCancelled, nil)
 	if err != ctxCancelled.Err() {
 		t.Errorf("TickerRateLimiter.Accept() = %v, want %v", err, ctxCancelled.Err())
 	}


### PR DESCRIPTION
The first call returns without waiting for a full tick so it should take a minimum 490ms.

![image](https://github.com/GoogleCloudPlatform/k8s-cloud-provider/assets/8083990/c99fb4c2-a0c0-424c-890b-e8f4e2dde128)

This would still be unreliable, so simplified the test to not rely on time.
