### PR TITLE
Fixes the serial executor test

### DIFF
--- a/pkg/cloud/rgraph/exec/action_test.go
+++ b/pkg/cloud/rgraph/exec/action_test.go
@@ -32,7 +32,7 @@ type testAction struct {
 	name    string
 	events  EventList
 	err     error
-	runHook func() error
+	runHook func(context.Context) error
 }
 
 func (a *testAction) String() string {
@@ -43,9 +43,9 @@ func (a *testAction) DryRun() EventList {
 	return a.events
 }
 
-func (a *testAction) Run(context.Context, cloud.Cloud) (EventList, error) {
+func (a *testAction) Run(ctx context.Context, _ cloud.Cloud) (EventList, error) {
 	if a.runHook != nil {
-		if runErr := a.runHook(); runErr != nil {
+		if runErr := a.runHook(ctx); runErr != nil {
 			a.err = runErr
 		}
 	}

--- a/pkg/cloud/rgraph/exec/executor_parallel_test.go
+++ b/pkg/cloud/rgraph/exec/executor_parallel_test.go
@@ -241,7 +241,7 @@ func TestParallelExecutorTimeoutOptions(t *testing.T) {
 			c := &testAction{
 				name:   "C",
 				events: EventList{StringEvent("C")},
-				runHook: func() error {
+				runHook: func(ctx context.Context) error {
 					t.Log("Action c run hook, wait 5sec")
 					time.Sleep(5 * time.Second)
 					t.Log("Action c run hook, finish wait")


### PR DESCRIPTION
* Make testAction respond to the context cancellation as documented in the docstring for serialExecutor.
* Pass context to the testAction so it can be used to cancel the blocking action.
* Adjust timers so the test is not as sensitive to timing issues.