### PR TITLE
export FieldType function so it can be used outside cloud package

### DIFF
--- a/pkg/cloud/api/check.go
+++ b/pkg/cloud/api/check.go
@@ -39,7 +39,7 @@ func checkPostAccess(traits *FieldTraits, v reflect.Value) error {
 			if ft.Name == "NullFields" || ft.Name == "ForceSendFields" {
 				continue
 			}
-			fType := traits.fieldType(p.Field(ft.Name))
+			fType := traits.FieldType(p.Field(ft.Name))
 			fv := v.Field(i)
 			fp := p.Field(ft.Name)
 

--- a/pkg/cloud/api/diff.go
+++ b/pkg/cloud/api/diff.go
@@ -156,7 +156,7 @@ func (d *differ[T]) do(p Path, av, bv reflect.Value) error {
 			}
 
 			fp := p.Field(aft.Name)
-			switch d.traits.fieldType(fp) {
+			switch d.traits.FieldType(fp) {
 			case FieldTypeOutputOnly, FieldTypeSystem:
 				continue
 			}

--- a/pkg/cloud/api/fill.go
+++ b/pkg/cloud/api/fill.go
@@ -176,7 +176,7 @@ func fillNullAndForceSend(traits *FieldTraits, v reflect.Value) error {
 			if ft.Name == "NullFields" || ft.Name == "ForceSendFields" {
 				continue
 			}
-			fType := traits.fieldType(p.Field(ft.Name))
+			fType := traits.FieldType(p.Field(ft.Name))
 			fv := v.Field(i)
 
 			if fType == FieldTypeNonZeroValue {

--- a/pkg/cloud/api/type_trait.go
+++ b/pkg/cloud/api/type_trait.go
@@ -195,7 +195,8 @@ func (dt *FieldTraits) Clone() *FieldTraits {
 	}
 }
 
-func (dt *FieldTraits) fieldType(p Path) FieldType { return dt.fieldTrait(p).fType }
+// FieldType returns field trait type for a given path
+func (dt *FieldTraits) FieldType(p Path) FieldType { return dt.fieldTrait(p).fType }
 
 func (dt *FieldTraits) fieldTrait(p Path) fieldTrait {
 	// TODO(bowei): this can be made very efficient with a tree, early bailout


### PR DESCRIPTION
FieldType function returns field's type set for a given rNode resource. This function is private and cannot be used outside cloud package. Reading field's type is needed for rGraph integration with internal APIs.    