### PR TITLE
Accept 400 as a valid error code for zone/region that does not exist

### DIFF
--- a/e2e/regions_test.go
+++ b/e2e/regions_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"google.golang.org/api/googleapi"
 )
 
 func TestRegions(t *testing.T) {
@@ -54,5 +55,11 @@ func TestRegions(t *testing.T) {
 
 	const invalidZone = "moonlab1"
 	_, err = theCloud.Regions().Get(ctx, meta.GlobalKey(invalidZone))
-	checkErrCode(t, err, 404, "Regions.Get()")
+	gerr, ok := err.(*googleapi.Error)
+	if !ok {
+		t.Fatalf("Regions.Get(): invalid error type, want *googleapi.Error, got %T", err)
+	}
+	if gerr.Code != 400 && gerr.Code != 404 {
+		t.Fatalf("Regions.Get(): got code %d, want {400, 404} (err: %v)", gerr.Code, err)
+	}
 }

--- a/e2e/zones_test.go
+++ b/e2e/zones_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"google.golang.org/api/googleapi"
 )
 
 func TestZones(t *testing.T) {
@@ -54,5 +55,11 @@ func TestZones(t *testing.T) {
 
 	const invalidZone = "moonlab1-c"
 	_, err = theCloud.Zones().Get(ctx, meta.GlobalKey(invalidZone))
-	checkErrCode(t, err, 404, "Zones.Get()")
+	gerr, ok := err.(*googleapi.Error)
+	if !ok {
+		t.Fatalf("Zones.Get(): invalid error type, want *googleapi.Error, got %T", err)
+	}
+	if gerr.Code != 400 && gerr.Code != 404 {
+		t.Fatalf("Zones.Get(): got code %d, want {400, 404} (err: %v)", gerr.Code, err)
+	}
 }


### PR DESCRIPTION
GCE API started returning 400 instead of expected 404 in some cases. This is expected behavior. More details available in the bug.

Bug: b/361065819