### PR TITLE
Fix compression mode

### DIFF
--- a/pkg/cloud/rgraph/rnode/backendservice/type_trait.go
+++ b/pkg/cloud/rgraph/rnode/backendservice/type_trait.go
@@ -49,7 +49,6 @@ func (*typeTrait) FieldTraits(v meta.Version) *api.FieldTraits {
 
 	dt.NonZeroValue(api.Path{}.Pointer().Field("LoadBalancingScheme"))
 	dt.NonZeroValue(api.Path{}.Pointer().Field("Protocol"))
-	dt.NonZeroValue(api.Path{}.Pointer().Field("CompressionMode"))
 	// TODO(kl52752) change this field to mandatory after fixing type traits check.
 	// Type traits check should be per path and not inherited from parent.
 	dt.AllowZeroValue(api.Path{}.Pointer().Field("ConnectionDraining"))
@@ -68,5 +67,6 @@ func (*typeTrait) FieldTraits(v meta.Version) *api.FieldTraits {
 		dt.NonZeroValue(api.Path{}.Pointer().Field("VpcNetworkScope"))
 		dt.NonZeroValue(api.Path{}.Pointer().Field("ExternalManagedMigrationState"))
 	}
+
 	return dt
 }


### PR DESCRIPTION
We need to leave compression mode empty as Compression mode can only be specified with EXTERNAL or EXTERNAL_MANAGED load balancing scheme.  In order to do so we need to allow zero value on the field.