### PR TITLE
Add resource key to observer CallContext.

### DIFF
--- a/pkg/cloud/context.go
+++ b/pkg/cloud/context.go
@@ -43,4 +43,6 @@ type CallContextKey struct {
 	Version meta.Version
 	// Service is the service being invoked (e.g. "Firewalls", "BackendServices")
 	Service string
+	// Resource is the key of the resource being operated on.
+	Resource *meta.Key
 }

--- a/pkg/cloud/gen.go
+++ b/pkg/cloud/gen.go
@@ -3552,6 +3552,7 @@ func (g *GCEAddresses) Get(ctx context.Context, key *meta.Key, options ...Option
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAddresses.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -3575,6 +3576,7 @@ func (g *GCEAddresses) Get(ctx context.Context, key *meta.Key, options ...Option
 func (g *GCEAddresses) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.Address, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAddresses.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Addresses")
 
 	ck := &CallContextKey{
@@ -3582,6 +3584,7 @@ func (g *GCEAddresses) List(ctx context.Context, region string, fl *filter.F, op
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -3640,6 +3643,7 @@ func (g *GCEAddresses) Insert(ctx context.Context, key *meta.Key, obj *computega
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAddresses.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -3681,6 +3685,7 @@ func (g *GCEAddresses) Delete(ctx context.Context, key *meta.Key, options ...Opt
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAddresses.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -3718,6 +3723,7 @@ func (g *GCEAddresses) AggregatedList(ctx context.Context, fl *filter.F, options
 		Operation: "AggregatedList",
 		Version:   meta.Version("ga"),
 		Service:   "Addresses",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEAddresses.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -4016,6 +4022,7 @@ func (g *GCEAlphaAddresses) Get(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaAddresses.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -4039,6 +4046,7 @@ func (g *GCEAlphaAddresses) Get(ctx context.Context, key *meta.Key, options ...O
 func (g *GCEAlphaAddresses) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.Address, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaAddresses.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "Addresses")
 
 	ck := &CallContextKey{
@@ -4046,6 +4054,7 @@ func (g *GCEAlphaAddresses) List(ctx context.Context, region string, fl *filter.
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -4104,6 +4113,7 @@ func (g *GCEAlphaAddresses) Insert(ctx context.Context, key *meta.Key, obj *comp
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaAddresses.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -4145,6 +4155,7 @@ func (g *GCEAlphaAddresses) Delete(ctx context.Context, key *meta.Key, options .
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaAddresses.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -4182,6 +4193,7 @@ func (g *GCEAlphaAddresses) AggregatedList(ctx context.Context, fl *filter.F, op
 		Operation: "AggregatedList",
 		Version:   meta.Version("alpha"),
 		Service:   "Addresses",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEAlphaAddresses.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -4480,6 +4492,7 @@ func (g *GCEBetaAddresses) Get(ctx context.Context, key *meta.Key, options ...Op
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaAddresses.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -4503,6 +4516,7 @@ func (g *GCEBetaAddresses) Get(ctx context.Context, key *meta.Key, options ...Op
 func (g *GCEBetaAddresses) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.Address, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaAddresses.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "Addresses")
 
 	ck := &CallContextKey{
@@ -4510,6 +4524,7 @@ func (g *GCEBetaAddresses) List(ctx context.Context, region string, fl *filter.F
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -4568,6 +4583,7 @@ func (g *GCEBetaAddresses) Insert(ctx context.Context, key *meta.Key, obj *compu
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaAddresses.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -4609,6 +4625,7 @@ func (g *GCEBetaAddresses) Delete(ctx context.Context, key *meta.Key, options ..
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "Addresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaAddresses.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -4646,6 +4663,7 @@ func (g *GCEBetaAddresses) AggregatedList(ctx context.Context, fl *filter.F, opt
 		Operation: "AggregatedList",
 		Version:   meta.Version("beta"),
 		Service:   "Addresses",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEBetaAddresses.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -4903,6 +4921,7 @@ func (g *GCEAlphaGlobalAddresses) Get(ctx context.Context, key *meta.Key, option
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaGlobalAddresses.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -4926,6 +4945,7 @@ func (g *GCEAlphaGlobalAddresses) Get(ctx context.Context, key *meta.Key, option
 func (g *GCEAlphaGlobalAddresses) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.Address, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaGlobalAddresses.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "GlobalAddresses")
 
 	ck := &CallContextKey{
@@ -4933,6 +4953,7 @@ func (g *GCEAlphaGlobalAddresses) List(ctx context.Context, fl *filter.F, option
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -4991,6 +5012,7 @@ func (g *GCEAlphaGlobalAddresses) Insert(ctx context.Context, key *meta.Key, obj
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalAddresses.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -5032,6 +5054,7 @@ func (g *GCEAlphaGlobalAddresses) Delete(ctx context.Context, key *meta.Key, opt
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalAddresses.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -5270,6 +5293,7 @@ func (g *GCEBetaGlobalAddresses) Get(ctx context.Context, key *meta.Key, options
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaGlobalAddresses.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -5293,6 +5317,7 @@ func (g *GCEBetaGlobalAddresses) Get(ctx context.Context, key *meta.Key, options
 func (g *GCEBetaGlobalAddresses) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.Address, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaGlobalAddresses.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "GlobalAddresses")
 
 	ck := &CallContextKey{
@@ -5300,6 +5325,7 @@ func (g *GCEBetaGlobalAddresses) List(ctx context.Context, fl *filter.F, options
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -5358,6 +5384,7 @@ func (g *GCEBetaGlobalAddresses) Insert(ctx context.Context, key *meta.Key, obj 
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalAddresses.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -5399,6 +5426,7 @@ func (g *GCEBetaGlobalAddresses) Delete(ctx context.Context, key *meta.Key, opti
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalAddresses.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -5637,6 +5665,7 @@ func (g *GCEGlobalAddresses) Get(ctx context.Context, key *meta.Key, options ...
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEGlobalAddresses.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -5660,6 +5689,7 @@ func (g *GCEGlobalAddresses) Get(ctx context.Context, key *meta.Key, options ...
 func (g *GCEGlobalAddresses) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.Address, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEGlobalAddresses.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "GlobalAddresses")
 
 	ck := &CallContextKey{
@@ -5667,6 +5697,7 @@ func (g *GCEGlobalAddresses) List(ctx context.Context, fl *filter.F, options ...
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -5725,6 +5756,7 @@ func (g *GCEGlobalAddresses) Insert(ctx context.Context, key *meta.Key, obj *com
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalAddresses.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -5766,6 +5798,7 @@ func (g *GCEGlobalAddresses) Delete(ctx context.Context, key *meta.Key, options 
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalAddresses",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalAddresses.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6102,6 +6135,7 @@ func (g *GCEBackendServices) Get(ctx context.Context, key *meta.Key, options ...
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBackendServices.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -6125,6 +6159,7 @@ func (g *GCEBackendServices) Get(ctx context.Context, key *meta.Key, options ...
 func (g *GCEBackendServices) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.BackendService, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBackendServices.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "BackendServices")
 
 	ck := &CallContextKey{
@@ -6132,6 +6167,7 @@ func (g *GCEBackendServices) List(ctx context.Context, fl *filter.F, options ...
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -6190,6 +6226,7 @@ func (g *GCEBackendServices) Insert(ctx context.Context, key *meta.Key, obj *com
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBackendServices.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6231,6 +6268,7 @@ func (g *GCEBackendServices) Delete(ctx context.Context, key *meta.Key, options 
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBackendServices.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6268,6 +6306,7 @@ func (g *GCEBackendServices) AggregatedList(ctx context.Context, fl *filter.F, o
 		Operation: "AggregatedList",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEBackendServices.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -6328,6 +6367,7 @@ func (g *GCEBackendServices) AddSignedUrlKey(ctx context.Context, key *meta.Key,
 		Operation: "AddSignedUrlKey",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBackendServices.AddSignedUrlKey(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6370,6 +6410,7 @@ func (g *GCEBackendServices) DeleteSignedUrlKey(ctx context.Context, key *meta.K
 		Operation: "DeleteSignedUrlKey",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBackendServices.DeleteSignedUrlKey(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6412,6 +6453,7 @@ func (g *GCEBackendServices) GetHealth(ctx context.Context, key *meta.Key, arg0 
 		Operation: "GetHealth",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBackendServices.GetHealth(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6445,6 +6487,7 @@ func (g *GCEBackendServices) Patch(ctx context.Context, key *meta.Key, arg0 *com
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBackendServices.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6487,6 +6530,7 @@ func (g *GCEBackendServices) SetSecurityPolicy(ctx context.Context, key *meta.Ke
 		Operation: "SetSecurityPolicy",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBackendServices.SetSecurityPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6529,6 +6573,7 @@ func (g *GCEBackendServices) Update(ctx context.Context, key *meta.Key, arg0 *co
 		Operation: "Update",
 		Version:   meta.Version("ga"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBackendServices.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6856,6 +6901,7 @@ func (g *GCEBetaBackendServices) Get(ctx context.Context, key *meta.Key, options
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaBackendServices.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -6879,6 +6925,7 @@ func (g *GCEBetaBackendServices) Get(ctx context.Context, key *meta.Key, options
 func (g *GCEBetaBackendServices) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.BackendService, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaBackendServices.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "BackendServices")
 
 	ck := &CallContextKey{
@@ -6886,6 +6933,7 @@ func (g *GCEBetaBackendServices) List(ctx context.Context, fl *filter.F, options
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -6944,6 +6992,7 @@ func (g *GCEBetaBackendServices) Insert(ctx context.Context, key *meta.Key, obj 
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaBackendServices.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -6985,6 +7034,7 @@ func (g *GCEBetaBackendServices) Delete(ctx context.Context, key *meta.Key, opti
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaBackendServices.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7022,6 +7072,7 @@ func (g *GCEBetaBackendServices) AggregatedList(ctx context.Context, fl *filter.
 		Operation: "AggregatedList",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEBetaBackendServices.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -7082,6 +7133,7 @@ func (g *GCEBetaBackendServices) AddSignedUrlKey(ctx context.Context, key *meta.
 		Operation: "AddSignedUrlKey",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaBackendServices.AddSignedUrlKey(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7124,6 +7176,7 @@ func (g *GCEBetaBackendServices) DeleteSignedUrlKey(ctx context.Context, key *me
 		Operation: "DeleteSignedUrlKey",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaBackendServices.DeleteSignedUrlKey(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7166,6 +7219,7 @@ func (g *GCEBetaBackendServices) Patch(ctx context.Context, key *meta.Key, arg0 
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaBackendServices.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7208,6 +7262,7 @@ func (g *GCEBetaBackendServices) SetSecurityPolicy(ctx context.Context, key *met
 		Operation: "SetSecurityPolicy",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaBackendServices.SetSecurityPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7250,6 +7305,7 @@ func (g *GCEBetaBackendServices) Update(ctx context.Context, key *meta.Key, arg0
 		Operation: "Update",
 		Version:   meta.Version("beta"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaBackendServices.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7577,6 +7633,7 @@ func (g *GCEAlphaBackendServices) Get(ctx context.Context, key *meta.Key, option
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaBackendServices.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -7600,6 +7657,7 @@ func (g *GCEAlphaBackendServices) Get(ctx context.Context, key *meta.Key, option
 func (g *GCEAlphaBackendServices) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.BackendService, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaBackendServices.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "BackendServices")
 
 	ck := &CallContextKey{
@@ -7607,6 +7665,7 @@ func (g *GCEAlphaBackendServices) List(ctx context.Context, fl *filter.F, option
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -7665,6 +7724,7 @@ func (g *GCEAlphaBackendServices) Insert(ctx context.Context, key *meta.Key, obj
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaBackendServices.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7706,6 +7766,7 @@ func (g *GCEAlphaBackendServices) Delete(ctx context.Context, key *meta.Key, opt
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaBackendServices.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7743,6 +7804,7 @@ func (g *GCEAlphaBackendServices) AggregatedList(ctx context.Context, fl *filter
 		Operation: "AggregatedList",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEAlphaBackendServices.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -7803,6 +7865,7 @@ func (g *GCEAlphaBackendServices) AddSignedUrlKey(ctx context.Context, key *meta
 		Operation: "AddSignedUrlKey",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaBackendServices.AddSignedUrlKey(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7845,6 +7908,7 @@ func (g *GCEAlphaBackendServices) DeleteSignedUrlKey(ctx context.Context, key *m
 		Operation: "DeleteSignedUrlKey",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaBackendServices.DeleteSignedUrlKey(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7887,6 +7951,7 @@ func (g *GCEAlphaBackendServices) Patch(ctx context.Context, key *meta.Key, arg0
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaBackendServices.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7929,6 +7994,7 @@ func (g *GCEAlphaBackendServices) SetSecurityPolicy(ctx context.Context, key *me
 		Operation: "SetSecurityPolicy",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaBackendServices.SetSecurityPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -7971,6 +8037,7 @@ func (g *GCEAlphaBackendServices) Update(ctx context.Context, key *meta.Key, arg
 		Operation: "Update",
 		Version:   meta.Version("alpha"),
 		Service:   "BackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaBackendServices.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -8253,6 +8320,7 @@ func (g *GCERegionBackendServices) Get(ctx context.Context, key *meta.Key, optio
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegionBackendServices.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -8276,6 +8344,7 @@ func (g *GCERegionBackendServices) Get(ctx context.Context, key *meta.Key, optio
 func (g *GCERegionBackendServices) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.BackendService, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERegionBackendServices.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "RegionBackendServices")
 
 	ck := &CallContextKey{
@@ -8283,6 +8352,7 @@ func (g *GCERegionBackendServices) List(ctx context.Context, region string, fl *
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -8341,6 +8411,7 @@ func (g *GCERegionBackendServices) Insert(ctx context.Context, key *meta.Key, ob
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionBackendServices.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -8382,6 +8453,7 @@ func (g *GCERegionBackendServices) Delete(ctx context.Context, key *meta.Key, op
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionBackendServices.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -8423,6 +8495,7 @@ func (g *GCERegionBackendServices) GetHealth(ctx context.Context, key *meta.Key,
 		Operation: "GetHealth",
 		Version:   meta.Version("ga"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionBackendServices.GetHealth(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -8456,6 +8529,7 @@ func (g *GCERegionBackendServices) Patch(ctx context.Context, key *meta.Key, arg
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionBackendServices.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -8498,6 +8572,7 @@ func (g *GCERegionBackendServices) SetSecurityPolicy(ctx context.Context, key *m
 		Operation: "SetSecurityPolicy",
 		Version:   meta.Version("ga"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionBackendServices.SetSecurityPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -8540,6 +8615,7 @@ func (g *GCERegionBackendServices) Update(ctx context.Context, key *meta.Key, ar
 		Operation: "Update",
 		Version:   meta.Version("ga"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionBackendServices.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -8822,6 +8898,7 @@ func (g *GCEAlphaRegionBackendServices) Get(ctx context.Context, key *meta.Key, 
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaRegionBackendServices.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -8845,6 +8922,7 @@ func (g *GCEAlphaRegionBackendServices) Get(ctx context.Context, key *meta.Key, 
 func (g *GCEAlphaRegionBackendServices) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.BackendService, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaRegionBackendServices.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "RegionBackendServices")
 
 	ck := &CallContextKey{
@@ -8852,6 +8930,7 @@ func (g *GCEAlphaRegionBackendServices) List(ctx context.Context, region string,
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -8910,6 +8989,7 @@ func (g *GCEAlphaRegionBackendServices) Insert(ctx context.Context, key *meta.Ke
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionBackendServices.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -8951,6 +9031,7 @@ func (g *GCEAlphaRegionBackendServices) Delete(ctx context.Context, key *meta.Ke
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionBackendServices.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -8992,6 +9073,7 @@ func (g *GCEAlphaRegionBackendServices) GetHealth(ctx context.Context, key *meta
 		Operation: "GetHealth",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionBackendServices.GetHealth(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9025,6 +9107,7 @@ func (g *GCEAlphaRegionBackendServices) Patch(ctx context.Context, key *meta.Key
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionBackendServices.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9067,6 +9150,7 @@ func (g *GCEAlphaRegionBackendServices) SetSecurityPolicy(ctx context.Context, k
 		Operation: "SetSecurityPolicy",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionBackendServices.SetSecurityPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9109,6 +9193,7 @@ func (g *GCEAlphaRegionBackendServices) Update(ctx context.Context, key *meta.Ke
 		Operation: "Update",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionBackendServices.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9391,6 +9476,7 @@ func (g *GCEBetaRegionBackendServices) Get(ctx context.Context, key *meta.Key, o
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaRegionBackendServices.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -9414,6 +9500,7 @@ func (g *GCEBetaRegionBackendServices) Get(ctx context.Context, key *meta.Key, o
 func (g *GCEBetaRegionBackendServices) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.BackendService, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaRegionBackendServices.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "RegionBackendServices")
 
 	ck := &CallContextKey{
@@ -9421,6 +9508,7 @@ func (g *GCEBetaRegionBackendServices) List(ctx context.Context, region string, 
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -9479,6 +9567,7 @@ func (g *GCEBetaRegionBackendServices) Insert(ctx context.Context, key *meta.Key
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionBackendServices.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9520,6 +9609,7 @@ func (g *GCEBetaRegionBackendServices) Delete(ctx context.Context, key *meta.Key
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionBackendServices.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9561,6 +9651,7 @@ func (g *GCEBetaRegionBackendServices) GetHealth(ctx context.Context, key *meta.
 		Operation: "GetHealth",
 		Version:   meta.Version("beta"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionBackendServices.GetHealth(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9594,6 +9685,7 @@ func (g *GCEBetaRegionBackendServices) Patch(ctx context.Context, key *meta.Key,
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionBackendServices.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9636,6 +9728,7 @@ func (g *GCEBetaRegionBackendServices) SetSecurityPolicy(ctx context.Context, ke
 		Operation: "SetSecurityPolicy",
 		Version:   meta.Version("beta"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionBackendServices.SetSecurityPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9678,6 +9771,7 @@ func (g *GCEBetaRegionBackendServices) Update(ctx context.Context, key *meta.Key
 		Operation: "Update",
 		Version:   meta.Version("beta"),
 		Service:   "RegionBackendServices",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionBackendServices.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -9930,6 +10024,7 @@ func (g *GCEDisks) Get(ctx context.Context, key *meta.Key, options ...Option) (*
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Disks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEDisks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -9953,6 +10048,7 @@ func (g *GCEDisks) Get(ctx context.Context, key *meta.Key, options ...Option) (*
 func (g *GCEDisks) List(ctx context.Context, zone string, fl *filter.F, options ...Option) ([]*computega.Disk, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEDisks.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Disks")
 
 	ck := &CallContextKey{
@@ -9960,6 +10056,7 @@ func (g *GCEDisks) List(ctx context.Context, zone string, fl *filter.F, options 
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Disks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -10018,6 +10115,7 @@ func (g *GCEDisks) Insert(ctx context.Context, key *meta.Key, obj *computega.Dis
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Disks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEDisks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -10059,6 +10157,7 @@ func (g *GCEDisks) Delete(ctx context.Context, key *meta.Key, options ...Option)
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Disks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEDisks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -10100,6 +10199,7 @@ func (g *GCEDisks) Resize(ctx context.Context, key *meta.Key, arg0 *computega.Di
 		Operation: "Resize",
 		Version:   meta.Version("ga"),
 		Service:   "Disks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEDisks.Resize(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -10352,6 +10452,7 @@ func (g *GCERegionDisks) Get(ctx context.Context, key *meta.Key, options ...Opti
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "RegionDisks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegionDisks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -10375,6 +10476,7 @@ func (g *GCERegionDisks) Get(ctx context.Context, key *meta.Key, options ...Opti
 func (g *GCERegionDisks) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.Disk, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERegionDisks.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "RegionDisks")
 
 	ck := &CallContextKey{
@@ -10382,6 +10484,7 @@ func (g *GCERegionDisks) List(ctx context.Context, region string, fl *filter.F, 
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "RegionDisks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -10440,6 +10543,7 @@ func (g *GCERegionDisks) Insert(ctx context.Context, key *meta.Key, obj *compute
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "RegionDisks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionDisks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -10481,6 +10585,7 @@ func (g *GCERegionDisks) Delete(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "RegionDisks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionDisks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -10522,6 +10627,7 @@ func (g *GCERegionDisks) Resize(ctx context.Context, key *meta.Key, arg0 *comput
 		Operation: "Resize",
 		Version:   meta.Version("ga"),
 		Service:   "RegionDisks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionDisks.Resize(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -10781,6 +10887,7 @@ func (g *GCEAlphaFirewalls) Get(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaFirewalls.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -10804,6 +10911,7 @@ func (g *GCEAlphaFirewalls) Get(ctx context.Context, key *meta.Key, options ...O
 func (g *GCEAlphaFirewalls) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.Firewall, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaFirewalls.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "Firewalls")
 
 	ck := &CallContextKey{
@@ -10811,6 +10919,7 @@ func (g *GCEAlphaFirewalls) List(ctx context.Context, fl *filter.F, options ...O
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -10869,6 +10978,7 @@ func (g *GCEAlphaFirewalls) Insert(ctx context.Context, key *meta.Key, obj *comp
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaFirewalls.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -10910,6 +11020,7 @@ func (g *GCEAlphaFirewalls) Delete(ctx context.Context, key *meta.Key, options .
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaFirewalls.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -10951,6 +11062,7 @@ func (g *GCEAlphaFirewalls) Patch(ctx context.Context, key *meta.Key, arg0 *comp
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaFirewalls.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -10993,6 +11105,7 @@ func (g *GCEAlphaFirewalls) Update(ctx context.Context, key *meta.Key, arg0 *com
 		Operation: "Update",
 		Version:   meta.Version("alpha"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaFirewalls.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -11252,6 +11365,7 @@ func (g *GCEBetaFirewalls) Get(ctx context.Context, key *meta.Key, options ...Op
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaFirewalls.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -11275,6 +11389,7 @@ func (g *GCEBetaFirewalls) Get(ctx context.Context, key *meta.Key, options ...Op
 func (g *GCEBetaFirewalls) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.Firewall, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaFirewalls.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "Firewalls")
 
 	ck := &CallContextKey{
@@ -11282,6 +11397,7 @@ func (g *GCEBetaFirewalls) List(ctx context.Context, fl *filter.F, options ...Op
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -11340,6 +11456,7 @@ func (g *GCEBetaFirewalls) Insert(ctx context.Context, key *meta.Key, obj *compu
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaFirewalls.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -11381,6 +11498,7 @@ func (g *GCEBetaFirewalls) Delete(ctx context.Context, key *meta.Key, options ..
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaFirewalls.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -11422,6 +11540,7 @@ func (g *GCEBetaFirewalls) Patch(ctx context.Context, key *meta.Key, arg0 *compu
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaFirewalls.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -11464,6 +11583,7 @@ func (g *GCEBetaFirewalls) Update(ctx context.Context, key *meta.Key, arg0 *comp
 		Operation: "Update",
 		Version:   meta.Version("beta"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaFirewalls.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -11723,6 +11843,7 @@ func (g *GCEFirewalls) Get(ctx context.Context, key *meta.Key, options ...Option
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEFirewalls.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -11746,6 +11867,7 @@ func (g *GCEFirewalls) Get(ctx context.Context, key *meta.Key, options ...Option
 func (g *GCEFirewalls) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.Firewall, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEFirewalls.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Firewalls")
 
 	ck := &CallContextKey{
@@ -11753,6 +11875,7 @@ func (g *GCEFirewalls) List(ctx context.Context, fl *filter.F, options ...Option
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -11811,6 +11934,7 @@ func (g *GCEFirewalls) Insert(ctx context.Context, key *meta.Key, obj *computega
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEFirewalls.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -11852,6 +11976,7 @@ func (g *GCEFirewalls) Delete(ctx context.Context, key *meta.Key, options ...Opt
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEFirewalls.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -11893,6 +12018,7 @@ func (g *GCEFirewalls) Patch(ctx context.Context, key *meta.Key, arg0 *computega
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEFirewalls.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -11935,6 +12061,7 @@ func (g *GCEFirewalls) Update(ctx context.Context, key *meta.Key, arg0 *computeg
 		Operation: "Update",
 		Version:   meta.Version("ga"),
 		Service:   "Firewalls",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEFirewalls.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12294,6 +12421,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) Get(ctx context.Context, key *meta.Key
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -12317,6 +12445,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) Get(ctx context.Context, key *meta.Key
 func (g *GCEAlphaNetworkFirewallPolicies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.FirewallPolicy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "NetworkFirewallPolicies")
 
 	ck := &CallContextKey{
@@ -12324,6 +12453,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) List(ctx context.Context, fl *filter.F
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -12382,6 +12512,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) Insert(ctx context.Context, key *meta.
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12423,6 +12554,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) Delete(ctx context.Context, key *meta.
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12464,6 +12596,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) AddAssociation(ctx context.Context, ke
 		Operation: "AddAssociation",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.AddAssociation(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12506,6 +12639,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) AddRule(ctx context.Context, key *meta
 		Operation: "AddRule",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.AddRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12548,6 +12682,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) CloneRules(ctx context.Context, key *m
 		Operation: "CloneRules",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.CloneRules(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12590,6 +12725,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) GetAssociation(ctx context.Context, ke
 		Operation: "GetAssociation",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.GetAssociation(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12623,6 +12759,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) GetIamPolicy(ctx context.Context, key 
 		Operation: "GetIamPolicy",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.GetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12656,6 +12793,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) GetRule(ctx context.Context, key *meta
 		Operation: "GetRule",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.GetRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12689,6 +12827,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) Patch(ctx context.Context, key *meta.K
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12731,6 +12870,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) PatchRule(ctx context.Context, key *me
 		Operation: "PatchRule",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.PatchRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12773,6 +12913,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) RemoveAssociation(ctx context.Context,
 		Operation: "RemoveAssociation",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.RemoveAssociation(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12815,6 +12956,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) RemoveRule(ctx context.Context, key *m
 		Operation: "RemoveRule",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.RemoveRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12857,6 +12999,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) SetIamPolicy(ctx context.Context, key 
 		Operation: "SetIamPolicy",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.SetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -12890,6 +13033,7 @@ func (g *GCEAlphaNetworkFirewallPolicies) TestIamPermissions(ctx context.Context
 		Operation: "TestIamPermissions",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkFirewallPolicies.TestIamPermissions(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13243,6 +13387,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) Get(ctx context.Context, key *me
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -13266,6 +13411,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) Get(ctx context.Context, key *me
 func (g *GCEAlphaRegionNetworkFirewallPolicies) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.FirewallPolicy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "RegionNetworkFirewallPolicies")
 
 	ck := &CallContextKey{
@@ -13273,6 +13419,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) List(ctx context.Context, region
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -13331,6 +13478,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) Insert(ctx context.Context, key 
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13372,6 +13520,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) Delete(ctx context.Context, key 
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13413,6 +13562,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) AddAssociation(ctx context.Conte
 		Operation: "AddAssociation",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.AddAssociation(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13455,6 +13605,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) AddRule(ctx context.Context, key
 		Operation: "AddRule",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.AddRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13497,6 +13648,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) CloneRules(ctx context.Context, 
 		Operation: "CloneRules",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.CloneRules(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13539,6 +13691,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) GetAssociation(ctx context.Conte
 		Operation: "GetAssociation",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.GetAssociation(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13572,6 +13725,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) GetIamPolicy(ctx context.Context
 		Operation: "GetIamPolicy",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.GetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13605,6 +13759,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) GetRule(ctx context.Context, key
 		Operation: "GetRule",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.GetRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13638,6 +13793,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) Patch(ctx context.Context, key *
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13680,6 +13836,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) PatchRule(ctx context.Context, k
 		Operation: "PatchRule",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.PatchRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13722,6 +13879,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) RemoveAssociation(ctx context.Co
 		Operation: "RemoveAssociation",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.RemoveAssociation(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13764,6 +13922,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) RemoveRule(ctx context.Context, 
 		Operation: "RemoveRule",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.RemoveRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13806,6 +13965,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) SetIamPolicy(ctx context.Context
 		Operation: "SetIamPolicy",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.SetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -13839,6 +13999,7 @@ func (g *GCEAlphaRegionNetworkFirewallPolicies) TestIamPermissions(ctx context.C
 		Operation: "TestIamPermissions",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkFirewallPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkFirewallPolicies.TestIamPermissions(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14102,6 +14263,7 @@ func (g *GCEForwardingRules) Get(ctx context.Context, key *meta.Key, options ...
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEForwardingRules.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -14125,6 +14287,7 @@ func (g *GCEForwardingRules) Get(ctx context.Context, key *meta.Key, options ...
 func (g *GCEForwardingRules) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.ForwardingRule, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEForwardingRules.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "ForwardingRules")
 
 	ck := &CallContextKey{
@@ -14132,6 +14295,7 @@ func (g *GCEForwardingRules) List(ctx context.Context, region string, fl *filter
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -14190,6 +14354,7 @@ func (g *GCEForwardingRules) Insert(ctx context.Context, key *meta.Key, obj *com
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEForwardingRules.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14231,6 +14396,7 @@ func (g *GCEForwardingRules) Delete(ctx context.Context, key *meta.Key, options 
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEForwardingRules.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14272,6 +14438,7 @@ func (g *GCEForwardingRules) Patch(ctx context.Context, key *meta.Key, arg0 *com
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEForwardingRules.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14314,6 +14481,7 @@ func (g *GCEForwardingRules) SetLabels(ctx context.Context, key *meta.Key, arg0 
 		Operation: "SetLabels",
 		Version:   meta.Version("ga"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEForwardingRules.SetLabels(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14356,6 +14524,7 @@ func (g *GCEForwardingRules) SetTarget(ctx context.Context, key *meta.Key, arg0 
 		Operation: "SetTarget",
 		Version:   meta.Version("ga"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEForwardingRules.SetTarget(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14628,6 +14797,7 @@ func (g *GCEAlphaForwardingRules) Get(ctx context.Context, key *meta.Key, option
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaForwardingRules.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -14651,6 +14821,7 @@ func (g *GCEAlphaForwardingRules) Get(ctx context.Context, key *meta.Key, option
 func (g *GCEAlphaForwardingRules) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.ForwardingRule, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaForwardingRules.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "ForwardingRules")
 
 	ck := &CallContextKey{
@@ -14658,6 +14829,7 @@ func (g *GCEAlphaForwardingRules) List(ctx context.Context, region string, fl *f
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -14716,6 +14888,7 @@ func (g *GCEAlphaForwardingRules) Insert(ctx context.Context, key *meta.Key, obj
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaForwardingRules.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14757,6 +14930,7 @@ func (g *GCEAlphaForwardingRules) Delete(ctx context.Context, key *meta.Key, opt
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaForwardingRules.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14798,6 +14972,7 @@ func (g *GCEAlphaForwardingRules) Patch(ctx context.Context, key *meta.Key, arg0
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaForwardingRules.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14840,6 +15015,7 @@ func (g *GCEAlphaForwardingRules) SetLabels(ctx context.Context, key *meta.Key, 
 		Operation: "SetLabels",
 		Version:   meta.Version("alpha"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaForwardingRules.SetLabels(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -14882,6 +15058,7 @@ func (g *GCEAlphaForwardingRules) SetTarget(ctx context.Context, key *meta.Key, 
 		Operation: "SetTarget",
 		Version:   meta.Version("alpha"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaForwardingRules.SetTarget(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15154,6 +15331,7 @@ func (g *GCEBetaForwardingRules) Get(ctx context.Context, key *meta.Key, options
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaForwardingRules.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -15177,6 +15355,7 @@ func (g *GCEBetaForwardingRules) Get(ctx context.Context, key *meta.Key, options
 func (g *GCEBetaForwardingRules) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.ForwardingRule, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaForwardingRules.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "ForwardingRules")
 
 	ck := &CallContextKey{
@@ -15184,6 +15363,7 @@ func (g *GCEBetaForwardingRules) List(ctx context.Context, region string, fl *fi
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -15242,6 +15422,7 @@ func (g *GCEBetaForwardingRules) Insert(ctx context.Context, key *meta.Key, obj 
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaForwardingRules.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15283,6 +15464,7 @@ func (g *GCEBetaForwardingRules) Delete(ctx context.Context, key *meta.Key, opti
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaForwardingRules.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15324,6 +15506,7 @@ func (g *GCEBetaForwardingRules) Patch(ctx context.Context, key *meta.Key, arg0 
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaForwardingRules.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15366,6 +15549,7 @@ func (g *GCEBetaForwardingRules) SetLabels(ctx context.Context, key *meta.Key, a
 		Operation: "SetLabels",
 		Version:   meta.Version("beta"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaForwardingRules.SetLabels(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15408,6 +15592,7 @@ func (g *GCEBetaForwardingRules) SetTarget(ctx context.Context, key *meta.Key, a
 		Operation: "SetTarget",
 		Version:   meta.Version("beta"),
 		Service:   "ForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaForwardingRules.SetTarget(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15677,6 +15862,7 @@ func (g *GCEAlphaGlobalForwardingRules) Get(ctx context.Context, key *meta.Key, 
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -15700,6 +15886,7 @@ func (g *GCEAlphaGlobalForwardingRules) Get(ctx context.Context, key *meta.Key, 
 func (g *GCEAlphaGlobalForwardingRules) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.ForwardingRule, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "GlobalForwardingRules")
 
 	ck := &CallContextKey{
@@ -15707,6 +15894,7 @@ func (g *GCEAlphaGlobalForwardingRules) List(ctx context.Context, fl *filter.F, 
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -15765,6 +15953,7 @@ func (g *GCEAlphaGlobalForwardingRules) Insert(ctx context.Context, key *meta.Ke
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15806,6 +15995,7 @@ func (g *GCEAlphaGlobalForwardingRules) Delete(ctx context.Context, key *meta.Ke
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15847,6 +16037,7 @@ func (g *GCEAlphaGlobalForwardingRules) Patch(ctx context.Context, key *meta.Key
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15889,6 +16080,7 @@ func (g *GCEAlphaGlobalForwardingRules) SetLabels(ctx context.Context, key *meta
 		Operation: "SetLabels",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.SetLabels(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -15931,6 +16123,7 @@ func (g *GCEAlphaGlobalForwardingRules) SetTarget(ctx context.Context, key *meta
 		Operation: "SetTarget",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalForwardingRules.SetTarget(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16200,6 +16393,7 @@ func (g *GCEBetaGlobalForwardingRules) Get(ctx context.Context, key *meta.Key, o
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaGlobalForwardingRules.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -16223,6 +16417,7 @@ func (g *GCEBetaGlobalForwardingRules) Get(ctx context.Context, key *meta.Key, o
 func (g *GCEBetaGlobalForwardingRules) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.ForwardingRule, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaGlobalForwardingRules.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "GlobalForwardingRules")
 
 	ck := &CallContextKey{
@@ -16230,6 +16425,7 @@ func (g *GCEBetaGlobalForwardingRules) List(ctx context.Context, fl *filter.F, o
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -16288,6 +16484,7 @@ func (g *GCEBetaGlobalForwardingRules) Insert(ctx context.Context, key *meta.Key
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalForwardingRules.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16329,6 +16526,7 @@ func (g *GCEBetaGlobalForwardingRules) Delete(ctx context.Context, key *meta.Key
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalForwardingRules.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16370,6 +16568,7 @@ func (g *GCEBetaGlobalForwardingRules) Patch(ctx context.Context, key *meta.Key,
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalForwardingRules.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16412,6 +16611,7 @@ func (g *GCEBetaGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.
 		Operation: "SetLabels",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalForwardingRules.SetLabels(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16454,6 +16654,7 @@ func (g *GCEBetaGlobalForwardingRules) SetTarget(ctx context.Context, key *meta.
 		Operation: "SetTarget",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalForwardingRules.SetTarget(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16723,6 +16924,7 @@ func (g *GCEGlobalForwardingRules) Get(ctx context.Context, key *meta.Key, optio
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEGlobalForwardingRules.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -16746,6 +16948,7 @@ func (g *GCEGlobalForwardingRules) Get(ctx context.Context, key *meta.Key, optio
 func (g *GCEGlobalForwardingRules) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.ForwardingRule, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEGlobalForwardingRules.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "GlobalForwardingRules")
 
 	ck := &CallContextKey{
@@ -16753,6 +16956,7 @@ func (g *GCEGlobalForwardingRules) List(ctx context.Context, fl *filter.F, optio
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -16811,6 +17015,7 @@ func (g *GCEGlobalForwardingRules) Insert(ctx context.Context, key *meta.Key, ob
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalForwardingRules.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16852,6 +17057,7 @@ func (g *GCEGlobalForwardingRules) Delete(ctx context.Context, key *meta.Key, op
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalForwardingRules.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16893,6 +17099,7 @@ func (g *GCEGlobalForwardingRules) Patch(ctx context.Context, key *meta.Key, arg
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalForwardingRules.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16935,6 +17142,7 @@ func (g *GCEGlobalForwardingRules) SetLabels(ctx context.Context, key *meta.Key,
 		Operation: "SetLabels",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalForwardingRules.SetLabels(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -16977,6 +17185,7 @@ func (g *GCEGlobalForwardingRules) SetTarget(ctx context.Context, key *meta.Key,
 		Operation: "SetTarget",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalForwardingRules",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalForwardingRules.SetTarget(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -17226,6 +17435,7 @@ func (g *GCEHealthChecks) Get(ctx context.Context, key *meta.Key, options ...Opt
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEHealthChecks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -17249,6 +17459,7 @@ func (g *GCEHealthChecks) Get(ctx context.Context, key *meta.Key, options ...Opt
 func (g *GCEHealthChecks) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.HealthCheck, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEHealthChecks.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "HealthChecks")
 
 	ck := &CallContextKey{
@@ -17256,6 +17467,7 @@ func (g *GCEHealthChecks) List(ctx context.Context, fl *filter.F, options ...Opt
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -17314,6 +17526,7 @@ func (g *GCEHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *comput
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEHealthChecks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -17355,6 +17568,7 @@ func (g *GCEHealthChecks) Delete(ctx context.Context, key *meta.Key, options ...
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEHealthChecks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -17396,6 +17610,7 @@ func (g *GCEHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *compu
 		Operation: "Update",
 		Version:   meta.Version("ga"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEHealthChecks.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -17645,6 +17860,7 @@ func (g *GCEAlphaHealthChecks) Get(ctx context.Context, key *meta.Key, options .
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaHealthChecks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -17668,6 +17884,7 @@ func (g *GCEAlphaHealthChecks) Get(ctx context.Context, key *meta.Key, options .
 func (g *GCEAlphaHealthChecks) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.HealthCheck, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaHealthChecks.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "HealthChecks")
 
 	ck := &CallContextKey{
@@ -17675,6 +17892,7 @@ func (g *GCEAlphaHealthChecks) List(ctx context.Context, fl *filter.F, options .
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -17733,6 +17951,7 @@ func (g *GCEAlphaHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *c
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaHealthChecks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -17774,6 +17993,7 @@ func (g *GCEAlphaHealthChecks) Delete(ctx context.Context, key *meta.Key, option
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaHealthChecks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -17815,6 +18035,7 @@ func (g *GCEAlphaHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *
 		Operation: "Update",
 		Version:   meta.Version("alpha"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaHealthChecks.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -18064,6 +18285,7 @@ func (g *GCEBetaHealthChecks) Get(ctx context.Context, key *meta.Key, options ..
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaHealthChecks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -18087,6 +18309,7 @@ func (g *GCEBetaHealthChecks) Get(ctx context.Context, key *meta.Key, options ..
 func (g *GCEBetaHealthChecks) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.HealthCheck, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaHealthChecks.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "HealthChecks")
 
 	ck := &CallContextKey{
@@ -18094,6 +18317,7 @@ func (g *GCEBetaHealthChecks) List(ctx context.Context, fl *filter.F, options ..
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -18152,6 +18376,7 @@ func (g *GCEBetaHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *co
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaHealthChecks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -18193,6 +18418,7 @@ func (g *GCEBetaHealthChecks) Delete(ctx context.Context, key *meta.Key, options
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaHealthChecks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -18234,6 +18460,7 @@ func (g *GCEBetaHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *c
 		Operation: "Update",
 		Version:   meta.Version("beta"),
 		Service:   "HealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaHealthChecks.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -18486,6 +18713,7 @@ func (g *GCEAlphaRegionHealthChecks) Get(ctx context.Context, key *meta.Key, opt
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaRegionHealthChecks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -18509,6 +18737,7 @@ func (g *GCEAlphaRegionHealthChecks) Get(ctx context.Context, key *meta.Key, opt
 func (g *GCEAlphaRegionHealthChecks) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.HealthCheck, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaRegionHealthChecks.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "RegionHealthChecks")
 
 	ck := &CallContextKey{
@@ -18516,6 +18745,7 @@ func (g *GCEAlphaRegionHealthChecks) List(ctx context.Context, region string, fl
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -18574,6 +18804,7 @@ func (g *GCEAlphaRegionHealthChecks) Insert(ctx context.Context, key *meta.Key, 
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionHealthChecks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -18615,6 +18846,7 @@ func (g *GCEAlphaRegionHealthChecks) Delete(ctx context.Context, key *meta.Key, 
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionHealthChecks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -18656,6 +18888,7 @@ func (g *GCEAlphaRegionHealthChecks) Update(ctx context.Context, key *meta.Key, 
 		Operation: "Update",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionHealthChecks.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -18908,6 +19141,7 @@ func (g *GCEBetaRegionHealthChecks) Get(ctx context.Context, key *meta.Key, opti
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaRegionHealthChecks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -18931,6 +19165,7 @@ func (g *GCEBetaRegionHealthChecks) Get(ctx context.Context, key *meta.Key, opti
 func (g *GCEBetaRegionHealthChecks) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.HealthCheck, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaRegionHealthChecks.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "RegionHealthChecks")
 
 	ck := &CallContextKey{
@@ -18938,6 +19173,7 @@ func (g *GCEBetaRegionHealthChecks) List(ctx context.Context, region string, fl 
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -18996,6 +19232,7 @@ func (g *GCEBetaRegionHealthChecks) Insert(ctx context.Context, key *meta.Key, o
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionHealthChecks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -19037,6 +19274,7 @@ func (g *GCEBetaRegionHealthChecks) Delete(ctx context.Context, key *meta.Key, o
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionHealthChecks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -19078,6 +19316,7 @@ func (g *GCEBetaRegionHealthChecks) Update(ctx context.Context, key *meta.Key, a
 		Operation: "Update",
 		Version:   meta.Version("beta"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionHealthChecks.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -19330,6 +19569,7 @@ func (g *GCERegionHealthChecks) Get(ctx context.Context, key *meta.Key, options 
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegionHealthChecks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -19353,6 +19593,7 @@ func (g *GCERegionHealthChecks) Get(ctx context.Context, key *meta.Key, options 
 func (g *GCERegionHealthChecks) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.HealthCheck, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERegionHealthChecks.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "RegionHealthChecks")
 
 	ck := &CallContextKey{
@@ -19360,6 +19601,7 @@ func (g *GCERegionHealthChecks) List(ctx context.Context, region string, fl *fil
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -19418,6 +19660,7 @@ func (g *GCERegionHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionHealthChecks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -19459,6 +19702,7 @@ func (g *GCERegionHealthChecks) Delete(ctx context.Context, key *meta.Key, optio
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionHealthChecks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -19500,6 +19744,7 @@ func (g *GCERegionHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 
 		Operation: "Update",
 		Version:   meta.Version("ga"),
 		Service:   "RegionHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionHealthChecks.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -19749,6 +19994,7 @@ func (g *GCEHttpHealthChecks) Get(ctx context.Context, key *meta.Key, options ..
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "HttpHealthChecks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEHttpHealthChecks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -19772,6 +20018,7 @@ func (g *GCEHttpHealthChecks) Get(ctx context.Context, key *meta.Key, options ..
 func (g *GCEHttpHealthChecks) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.HttpHealthCheck, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEHttpHealthChecks.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "HttpHealthChecks")
 
 	ck := &CallContextKey{
@@ -19779,6 +20026,7 @@ func (g *GCEHttpHealthChecks) List(ctx context.Context, fl *filter.F, options ..
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "HttpHealthChecks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -19837,6 +20085,7 @@ func (g *GCEHttpHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *co
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "HttpHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEHttpHealthChecks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -19878,6 +20127,7 @@ func (g *GCEHttpHealthChecks) Delete(ctx context.Context, key *meta.Key, options
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "HttpHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEHttpHealthChecks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -19919,6 +20169,7 @@ func (g *GCEHttpHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *c
 		Operation: "Update",
 		Version:   meta.Version("ga"),
 		Service:   "HttpHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEHttpHealthChecks.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -20168,6 +20419,7 @@ func (g *GCEHttpsHealthChecks) Get(ctx context.Context, key *meta.Key, options .
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "HttpsHealthChecks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEHttpsHealthChecks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -20191,6 +20443,7 @@ func (g *GCEHttpsHealthChecks) Get(ctx context.Context, key *meta.Key, options .
 func (g *GCEHttpsHealthChecks) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.HttpsHealthCheck, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEHttpsHealthChecks.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "HttpsHealthChecks")
 
 	ck := &CallContextKey{
@@ -20198,6 +20451,7 @@ func (g *GCEHttpsHealthChecks) List(ctx context.Context, fl *filter.F, options .
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "HttpsHealthChecks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -20256,6 +20510,7 @@ func (g *GCEHttpsHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *c
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "HttpsHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEHttpsHealthChecks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -20297,6 +20552,7 @@ func (g *GCEHttpsHealthChecks) Delete(ctx context.Context, key *meta.Key, option
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "HttpsHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEHttpsHealthChecks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -20338,6 +20594,7 @@ func (g *GCEHttpsHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *
 		Operation: "Update",
 		Version:   meta.Version("ga"),
 		Service:   "HttpsHealthChecks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEHttpsHealthChecks.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -20620,6 +20877,7 @@ func (g *GCEInstanceGroups) Get(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEInstanceGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -20643,6 +20901,7 @@ func (g *GCEInstanceGroups) Get(ctx context.Context, key *meta.Key, options ...O
 func (g *GCEInstanceGroups) List(ctx context.Context, zone string, fl *filter.F, options ...Option) ([]*computega.InstanceGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEInstanceGroups.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "InstanceGroups")
 
 	ck := &CallContextKey{
@@ -20650,6 +20909,7 @@ func (g *GCEInstanceGroups) List(ctx context.Context, zone string, fl *filter.F,
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -20708,6 +20968,7 @@ func (g *GCEInstanceGroups) Insert(ctx context.Context, key *meta.Key, obj *comp
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -20749,6 +21010,7 @@ func (g *GCEInstanceGroups) Delete(ctx context.Context, key *meta.Key, options .
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -20790,6 +21052,7 @@ func (g *GCEInstanceGroups) AddInstances(ctx context.Context, key *meta.Key, arg
 		Operation: "AddInstances",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroups.AddInstances(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -20832,6 +21095,7 @@ func (g *GCEInstanceGroups) ListInstances(ctx context.Context, key *meta.Key, ar
 		Operation: "ListInstances",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroups.ListInstances(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -20884,6 +21148,7 @@ func (g *GCEInstanceGroups) RemoveInstances(ctx context.Context, key *meta.Key, 
 		Operation: "RemoveInstances",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroups.RemoveInstances(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -20926,6 +21191,7 @@ func (g *GCEInstanceGroups) SetNamedPorts(ctx context.Context, key *meta.Key, ar
 		Operation: "SetNamedPorts",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroups.SetNamedPorts(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -21188,6 +21454,7 @@ func (g *GCEInstances) Get(ctx context.Context, key *meta.Key, options ...Option
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEInstances.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -21211,6 +21478,7 @@ func (g *GCEInstances) Get(ctx context.Context, key *meta.Key, options ...Option
 func (g *GCEInstances) List(ctx context.Context, zone string, fl *filter.F, options ...Option) ([]*computega.Instance, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEInstances.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Instances")
 
 	ck := &CallContextKey{
@@ -21218,6 +21486,7 @@ func (g *GCEInstances) List(ctx context.Context, zone string, fl *filter.F, opti
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -21276,6 +21545,7 @@ func (g *GCEInstances) Insert(ctx context.Context, key *meta.Key, obj *computega
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstances.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -21317,6 +21587,7 @@ func (g *GCEInstances) Delete(ctx context.Context, key *meta.Key, options ...Opt
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstances.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -21358,6 +21629,7 @@ func (g *GCEInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 *comp
 		Operation: "AttachDisk",
 		Version:   meta.Version("ga"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstances.AttachDisk(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -21400,6 +21672,7 @@ func (g *GCEInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 strin
 		Operation: "DetachDisk",
 		Version:   meta.Version("ga"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstances.DetachDisk(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -21672,6 +21945,7 @@ func (g *GCEBetaInstances) Get(ctx context.Context, key *meta.Key, options ...Op
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaInstances.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -21695,6 +21969,7 @@ func (g *GCEBetaInstances) Get(ctx context.Context, key *meta.Key, options ...Op
 func (g *GCEBetaInstances) List(ctx context.Context, zone string, fl *filter.F, options ...Option) ([]*computebeta.Instance, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaInstances.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "Instances")
 
 	ck := &CallContextKey{
@@ -21702,6 +21977,7 @@ func (g *GCEBetaInstances) List(ctx context.Context, zone string, fl *filter.F, 
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -21760,6 +22036,7 @@ func (g *GCEBetaInstances) Insert(ctx context.Context, key *meta.Key, obj *compu
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaInstances.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -21801,6 +22078,7 @@ func (g *GCEBetaInstances) Delete(ctx context.Context, key *meta.Key, options ..
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaInstances.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -21842,6 +22120,7 @@ func (g *GCEBetaInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 *
 		Operation: "AttachDisk",
 		Version:   meta.Version("beta"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaInstances.AttachDisk(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -21884,6 +22163,7 @@ func (g *GCEBetaInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 s
 		Operation: "DetachDisk",
 		Version:   meta.Version("beta"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaInstances.DetachDisk(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -21926,6 +22206,7 @@ func (g *GCEBetaInstances) UpdateNetworkInterface(ctx context.Context, key *meta
 		Operation: "UpdateNetworkInterface",
 		Version:   meta.Version("beta"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaInstances.UpdateNetworkInterface(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22198,6 +22479,7 @@ func (g *GCEAlphaInstances) Get(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaInstances.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -22221,6 +22503,7 @@ func (g *GCEAlphaInstances) Get(ctx context.Context, key *meta.Key, options ...O
 func (g *GCEAlphaInstances) List(ctx context.Context, zone string, fl *filter.F, options ...Option) ([]*computealpha.Instance, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaInstances.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "Instances")
 
 	ck := &CallContextKey{
@@ -22228,6 +22511,7 @@ func (g *GCEAlphaInstances) List(ctx context.Context, zone string, fl *filter.F,
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -22286,6 +22570,7 @@ func (g *GCEAlphaInstances) Insert(ctx context.Context, key *meta.Key, obj *comp
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaInstances.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22327,6 +22612,7 @@ func (g *GCEAlphaInstances) Delete(ctx context.Context, key *meta.Key, options .
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaInstances.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22368,6 +22654,7 @@ func (g *GCEAlphaInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 
 		Operation: "AttachDisk",
 		Version:   meta.Version("alpha"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaInstances.AttachDisk(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22410,6 +22697,7 @@ func (g *GCEAlphaInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 
 		Operation: "DetachDisk",
 		Version:   meta.Version("alpha"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaInstances.DetachDisk(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22452,6 +22740,7 @@ func (g *GCEAlphaInstances) UpdateNetworkInterface(ctx context.Context, key *met
 		Operation: "UpdateNetworkInterface",
 		Version:   meta.Version("alpha"),
 		Service:   "Instances",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaInstances.UpdateNetworkInterface(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22734,6 +23023,7 @@ func (g *GCEInstanceGroupManagers) Get(ctx context.Context, key *meta.Key, optio
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroupManagers",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEInstanceGroupManagers.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -22757,6 +23047,7 @@ func (g *GCEInstanceGroupManagers) Get(ctx context.Context, key *meta.Key, optio
 func (g *GCEInstanceGroupManagers) List(ctx context.Context, zone string, fl *filter.F, options ...Option) ([]*computega.InstanceGroupManager, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEInstanceGroupManagers.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "InstanceGroupManagers")
 
 	ck := &CallContextKey{
@@ -22764,6 +23055,7 @@ func (g *GCEInstanceGroupManagers) List(ctx context.Context, zone string, fl *fi
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroupManagers",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -22822,6 +23114,7 @@ func (g *GCEInstanceGroupManagers) Insert(ctx context.Context, key *meta.Key, ob
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroupManagers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroupManagers.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22863,6 +23156,7 @@ func (g *GCEInstanceGroupManagers) Delete(ctx context.Context, key *meta.Key, op
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroupManagers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroupManagers.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22904,6 +23198,7 @@ func (g *GCEInstanceGroupManagers) CreateInstances(ctx context.Context, key *met
 		Operation: "CreateInstances",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroupManagers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroupManagers.CreateInstances(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22946,6 +23241,7 @@ func (g *GCEInstanceGroupManagers) DeleteInstances(ctx context.Context, key *met
 		Operation: "DeleteInstances",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroupManagers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroupManagers.DeleteInstances(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -22988,6 +23284,7 @@ func (g *GCEInstanceGroupManagers) Resize(ctx context.Context, key *meta.Key, ar
 		Operation: "Resize",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroupManagers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroupManagers.Resize(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -23030,6 +23327,7 @@ func (g *GCEInstanceGroupManagers) SetInstanceTemplate(ctx context.Context, key 
 		Operation: "SetInstanceTemplate",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceGroupManagers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceGroupManagers.SetInstanceTemplate(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -23269,6 +23567,7 @@ func (g *GCEInstanceTemplates) Get(ctx context.Context, key *meta.Key, options .
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceTemplates",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEInstanceTemplates.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -23292,6 +23591,7 @@ func (g *GCEInstanceTemplates) Get(ctx context.Context, key *meta.Key, options .
 func (g *GCEInstanceTemplates) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.InstanceTemplate, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEInstanceTemplates.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "InstanceTemplates")
 
 	ck := &CallContextKey{
@@ -23299,6 +23599,7 @@ func (g *GCEInstanceTemplates) List(ctx context.Context, fl *filter.F, options .
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceTemplates",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -23357,6 +23658,7 @@ func (g *GCEInstanceTemplates) Insert(ctx context.Context, key *meta.Key, obj *c
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceTemplates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceTemplates.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -23398,6 +23700,7 @@ func (g *GCEInstanceTemplates) Delete(ctx context.Context, key *meta.Key, option
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "InstanceTemplates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEInstanceTemplates.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -23696,6 +23999,7 @@ func (g *GCEImages) Get(ctx context.Context, key *meta.Key, options ...Option) (
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEImages.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -23719,6 +24023,7 @@ func (g *GCEImages) Get(ctx context.Context, key *meta.Key, options ...Option) (
 func (g *GCEImages) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.Image, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEImages.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Images")
 
 	ck := &CallContextKey{
@@ -23726,6 +24031,7 @@ func (g *GCEImages) List(ctx context.Context, fl *filter.F, options ...Option) (
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -23784,6 +24090,7 @@ func (g *GCEImages) Insert(ctx context.Context, key *meta.Key, obj *computega.Im
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEImages.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -23825,6 +24132,7 @@ func (g *GCEImages) Delete(ctx context.Context, key *meta.Key, options ...Option
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEImages.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -23866,6 +24174,7 @@ func (g *GCEImages) GetFromFamily(ctx context.Context, key *meta.Key, options ..
 		Operation: "GetFromFamily",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEImages.GetFromFamily(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -23899,6 +24208,7 @@ func (g *GCEImages) GetIamPolicy(ctx context.Context, key *meta.Key, options ...
 		Operation: "GetIamPolicy",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEImages.GetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -23932,6 +24242,7 @@ func (g *GCEImages) Patch(ctx context.Context, key *meta.Key, arg0 *computega.Im
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEImages.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -23974,6 +24285,7 @@ func (g *GCEImages) SetIamPolicy(ctx context.Context, key *meta.Key, arg0 *compu
 		Operation: "SetIamPolicy",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEImages.SetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24007,6 +24319,7 @@ func (g *GCEImages) SetLabels(ctx context.Context, key *meta.Key, arg0 *computeg
 		Operation: "SetLabels",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEImages.SetLabels(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24049,6 +24362,7 @@ func (g *GCEImages) TestIamPermissions(ctx context.Context, key *meta.Key, arg0 
 		Operation: "TestIamPermissions",
 		Version:   meta.Version("ga"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEImages.TestIamPermissions(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24339,6 +24653,7 @@ func (g *GCEBetaImages) Get(ctx context.Context, key *meta.Key, options ...Optio
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaImages.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -24362,6 +24677,7 @@ func (g *GCEBetaImages) Get(ctx context.Context, key *meta.Key, options ...Optio
 func (g *GCEBetaImages) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.Image, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaImages.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "Images")
 
 	ck := &CallContextKey{
@@ -24369,6 +24685,7 @@ func (g *GCEBetaImages) List(ctx context.Context, fl *filter.F, options ...Optio
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -24427,6 +24744,7 @@ func (g *GCEBetaImages) Insert(ctx context.Context, key *meta.Key, obj *computeb
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaImages.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24468,6 +24786,7 @@ func (g *GCEBetaImages) Delete(ctx context.Context, key *meta.Key, options ...Op
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaImages.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24509,6 +24828,7 @@ func (g *GCEBetaImages) GetFromFamily(ctx context.Context, key *meta.Key, option
 		Operation: "GetFromFamily",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaImages.GetFromFamily(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24542,6 +24862,7 @@ func (g *GCEBetaImages) GetIamPolicy(ctx context.Context, key *meta.Key, options
 		Operation: "GetIamPolicy",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaImages.GetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24575,6 +24896,7 @@ func (g *GCEBetaImages) Patch(ctx context.Context, key *meta.Key, arg0 *computeb
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaImages.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24617,6 +24939,7 @@ func (g *GCEBetaImages) SetIamPolicy(ctx context.Context, key *meta.Key, arg0 *c
 		Operation: "SetIamPolicy",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaImages.SetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24650,6 +24973,7 @@ func (g *GCEBetaImages) SetLabels(ctx context.Context, key *meta.Key, arg0 *comp
 		Operation: "SetLabels",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaImages.SetLabels(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24692,6 +25016,7 @@ func (g *GCEBetaImages) TestIamPermissions(ctx context.Context, key *meta.Key, a
 		Operation: "TestIamPermissions",
 		Version:   meta.Version("beta"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaImages.TestIamPermissions(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -24982,6 +25307,7 @@ func (g *GCEAlphaImages) Get(ctx context.Context, key *meta.Key, options ...Opti
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaImages.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -25005,6 +25331,7 @@ func (g *GCEAlphaImages) Get(ctx context.Context, key *meta.Key, options ...Opti
 func (g *GCEAlphaImages) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.Image, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaImages.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "Images")
 
 	ck := &CallContextKey{
@@ -25012,6 +25339,7 @@ func (g *GCEAlphaImages) List(ctx context.Context, fl *filter.F, options ...Opti
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -25070,6 +25398,7 @@ func (g *GCEAlphaImages) Insert(ctx context.Context, key *meta.Key, obj *compute
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaImages.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25111,6 +25440,7 @@ func (g *GCEAlphaImages) Delete(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaImages.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25152,6 +25482,7 @@ func (g *GCEAlphaImages) GetFromFamily(ctx context.Context, key *meta.Key, optio
 		Operation: "GetFromFamily",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaImages.GetFromFamily(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25185,6 +25516,7 @@ func (g *GCEAlphaImages) GetIamPolicy(ctx context.Context, key *meta.Key, option
 		Operation: "GetIamPolicy",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaImages.GetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25218,6 +25550,7 @@ func (g *GCEAlphaImages) Patch(ctx context.Context, key *meta.Key, arg0 *compute
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaImages.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25260,6 +25593,7 @@ func (g *GCEAlphaImages) SetIamPolicy(ctx context.Context, key *meta.Key, arg0 *
 		Operation: "SetIamPolicy",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaImages.SetIamPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25293,6 +25627,7 @@ func (g *GCEAlphaImages) SetLabels(ctx context.Context, key *meta.Key, arg0 *com
 		Operation: "SetLabels",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaImages.SetLabels(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25335,6 +25670,7 @@ func (g *GCEAlphaImages) TestIamPermissions(ctx context.Context, key *meta.Key, 
 		Operation: "TestIamPermissions",
 		Version:   meta.Version("alpha"),
 		Service:   "Images",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaImages.TestIamPermissions(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25565,6 +25901,7 @@ func (g *GCEAlphaNetworks) Get(ctx context.Context, key *meta.Key, options ...Op
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaNetworks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -25588,6 +25925,7 @@ func (g *GCEAlphaNetworks) Get(ctx context.Context, key *meta.Key, options ...Op
 func (g *GCEAlphaNetworks) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.Network, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaNetworks.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "Networks")
 
 	ck := &CallContextKey{
@@ -25595,6 +25933,7 @@ func (g *GCEAlphaNetworks) List(ctx context.Context, fl *filter.F, options ...Op
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -25653,6 +25992,7 @@ func (g *GCEAlphaNetworks) Insert(ctx context.Context, key *meta.Key, obj *compu
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25694,6 +26034,7 @@ func (g *GCEAlphaNetworks) Delete(ctx context.Context, key *meta.Key, options ..
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -25932,6 +26273,7 @@ func (g *GCEBetaNetworks) Get(ctx context.Context, key *meta.Key, options ...Opt
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaNetworks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -25955,6 +26297,7 @@ func (g *GCEBetaNetworks) Get(ctx context.Context, key *meta.Key, options ...Opt
 func (g *GCEBetaNetworks) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.Network, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaNetworks.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "Networks")
 
 	ck := &CallContextKey{
@@ -25962,6 +26305,7 @@ func (g *GCEBetaNetworks) List(ctx context.Context, fl *filter.F, options ...Opt
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -26020,6 +26364,7 @@ func (g *GCEBetaNetworks) Insert(ctx context.Context, key *meta.Key, obj *comput
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaNetworks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -26061,6 +26406,7 @@ func (g *GCEBetaNetworks) Delete(ctx context.Context, key *meta.Key, options ...
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaNetworks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -26299,6 +26645,7 @@ func (g *GCENetworks) Get(ctx context.Context, key *meta.Key, options ...Option)
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCENetworks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -26322,6 +26669,7 @@ func (g *GCENetworks) Get(ctx context.Context, key *meta.Key, options ...Option)
 func (g *GCENetworks) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.Network, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCENetworks.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Networks")
 
 	ck := &CallContextKey{
@@ -26329,6 +26677,7 @@ func (g *GCENetworks) List(ctx context.Context, fl *filter.F, options ...Option)
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -26387,6 +26736,7 @@ func (g *GCENetworks) Insert(ctx context.Context, key *meta.Key, obj *computega.
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCENetworks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -26428,6 +26778,7 @@ func (g *GCENetworks) Delete(ctx context.Context, key *meta.Key, options ...Opti
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Networks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCENetworks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -26737,6 +27088,7 @@ func (g *GCEAlphaNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key, 
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaNetworkEndpointGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -26760,6 +27112,7 @@ func (g *GCEAlphaNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key, 
 func (g *GCEAlphaNetworkEndpointGroups) List(ctx context.Context, zone string, fl *filter.F, options ...Option) ([]*computealpha.NetworkEndpointGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaNetworkEndpointGroups.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "NetworkEndpointGroups")
 
 	ck := &CallContextKey{
@@ -26767,6 +27120,7 @@ func (g *GCEAlphaNetworkEndpointGroups) List(ctx context.Context, zone string, f
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -26825,6 +27179,7 @@ func (g *GCEAlphaNetworkEndpointGroups) Insert(ctx context.Context, key *meta.Ke
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkEndpointGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -26866,6 +27221,7 @@ func (g *GCEAlphaNetworkEndpointGroups) Delete(ctx context.Context, key *meta.Ke
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkEndpointGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -26903,6 +27259,7 @@ func (g *GCEAlphaNetworkEndpointGroups) AggregatedList(ctx context.Context, fl *
 		Operation: "AggregatedList",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEAlphaNetworkEndpointGroups.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -26963,6 +27320,7 @@ func (g *GCEAlphaNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Conte
 		Operation: "AttachNetworkEndpoints",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -27005,6 +27363,7 @@ func (g *GCEAlphaNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Conte
 		Operation: "DetachNetworkEndpoints",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -27047,6 +27406,7 @@ func (g *GCEAlphaNetworkEndpointGroups) ListNetworkEndpoints(ctx context.Context
 		Operation: "ListNetworkEndpoints",
 		Version:   meta.Version("alpha"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -27367,6 +27727,7 @@ func (g *GCEBetaNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key, o
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaNetworkEndpointGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -27390,6 +27751,7 @@ func (g *GCEBetaNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key, o
 func (g *GCEBetaNetworkEndpointGroups) List(ctx context.Context, zone string, fl *filter.F, options ...Option) ([]*computebeta.NetworkEndpointGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaNetworkEndpointGroups.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "NetworkEndpointGroups")
 
 	ck := &CallContextKey{
@@ -27397,6 +27759,7 @@ func (g *GCEBetaNetworkEndpointGroups) List(ctx context.Context, zone string, fl
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -27455,6 +27818,7 @@ func (g *GCEBetaNetworkEndpointGroups) Insert(ctx context.Context, key *meta.Key
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaNetworkEndpointGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -27496,6 +27860,7 @@ func (g *GCEBetaNetworkEndpointGroups) Delete(ctx context.Context, key *meta.Key
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaNetworkEndpointGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -27533,6 +27898,7 @@ func (g *GCEBetaNetworkEndpointGroups) AggregatedList(ctx context.Context, fl *f
 		Operation: "AggregatedList",
 		Version:   meta.Version("beta"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEBetaNetworkEndpointGroups.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -27593,6 +27959,7 @@ func (g *GCEBetaNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Contex
 		Operation: "AttachNetworkEndpoints",
 		Version:   meta.Version("beta"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -27635,6 +28002,7 @@ func (g *GCEBetaNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Contex
 		Operation: "DetachNetworkEndpoints",
 		Version:   meta.Version("beta"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -27677,6 +28045,7 @@ func (g *GCEBetaNetworkEndpointGroups) ListNetworkEndpoints(ctx context.Context,
 		Operation: "ListNetworkEndpoints",
 		Version:   meta.Version("beta"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -27997,6 +28366,7 @@ func (g *GCENetworkEndpointGroups) Get(ctx context.Context, key *meta.Key, optio
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCENetworkEndpointGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -28020,6 +28390,7 @@ func (g *GCENetworkEndpointGroups) Get(ctx context.Context, key *meta.Key, optio
 func (g *GCENetworkEndpointGroups) List(ctx context.Context, zone string, fl *filter.F, options ...Option) ([]*computega.NetworkEndpointGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCENetworkEndpointGroups.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "NetworkEndpointGroups")
 
 	ck := &CallContextKey{
@@ -28027,6 +28398,7 @@ func (g *GCENetworkEndpointGroups) List(ctx context.Context, zone string, fl *fi
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -28085,6 +28457,7 @@ func (g *GCENetworkEndpointGroups) Insert(ctx context.Context, key *meta.Key, ob
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCENetworkEndpointGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -28126,6 +28499,7 @@ func (g *GCENetworkEndpointGroups) Delete(ctx context.Context, key *meta.Key, op
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCENetworkEndpointGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -28163,6 +28537,7 @@ func (g *GCENetworkEndpointGroups) AggregatedList(ctx context.Context, fl *filte
 		Operation: "AggregatedList",
 		Version:   meta.Version("ga"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCENetworkEndpointGroups.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -28223,6 +28598,7 @@ func (g *GCENetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Context, k
 		Operation: "AttachNetworkEndpoints",
 		Version:   meta.Version("ga"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCENetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -28265,6 +28641,7 @@ func (g *GCENetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Context, k
 		Operation: "DetachNetworkEndpoints",
 		Version:   meta.Version("ga"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCENetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -28307,6 +28684,7 @@ func (g *GCENetworkEndpointGroups) ListNetworkEndpoints(ctx context.Context, key
 		Operation: "ListNetworkEndpoints",
 		Version:   meta.Version("ga"),
 		Service:   "NetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCENetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -28586,6 +28964,7 @@ func (g *GCEAlphaGlobalNetworkEndpointGroups) Get(ctx context.Context, key *meta
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaGlobalNetworkEndpointGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -28609,6 +28988,7 @@ func (g *GCEAlphaGlobalNetworkEndpointGroups) Get(ctx context.Context, key *meta
 func (g *GCEAlphaGlobalNetworkEndpointGroups) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.NetworkEndpointGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaGlobalNetworkEndpointGroups.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "GlobalNetworkEndpointGroups")
 
 	ck := &CallContextKey{
@@ -28616,6 +28996,7 @@ func (g *GCEAlphaGlobalNetworkEndpointGroups) List(ctx context.Context, fl *filt
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -28674,6 +29055,7 @@ func (g *GCEAlphaGlobalNetworkEndpointGroups) Insert(ctx context.Context, key *m
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalNetworkEndpointGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -28715,6 +29097,7 @@ func (g *GCEAlphaGlobalNetworkEndpointGroups) Delete(ctx context.Context, key *m
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalNetworkEndpointGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -28756,6 +29139,7 @@ func (g *GCEAlphaGlobalNetworkEndpointGroups) AttachNetworkEndpoints(ctx context
 		Operation: "AttachNetworkEndpoints",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -28798,6 +29182,7 @@ func (g *GCEAlphaGlobalNetworkEndpointGroups) DetachNetworkEndpoints(ctx context
 		Operation: "DetachNetworkEndpoints",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -28840,6 +29225,7 @@ func (g *GCEAlphaGlobalNetworkEndpointGroups) ListNetworkEndpoints(ctx context.C
 		Operation: "ListNetworkEndpoints",
 		Version:   meta.Version("alpha"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaGlobalNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29119,6 +29505,7 @@ func (g *GCEBetaGlobalNetworkEndpointGroups) Get(ctx context.Context, key *meta.
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaGlobalNetworkEndpointGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -29142,6 +29529,7 @@ func (g *GCEBetaGlobalNetworkEndpointGroups) Get(ctx context.Context, key *meta.
 func (g *GCEBetaGlobalNetworkEndpointGroups) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.NetworkEndpointGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaGlobalNetworkEndpointGroups.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "GlobalNetworkEndpointGroups")
 
 	ck := &CallContextKey{
@@ -29149,6 +29537,7 @@ func (g *GCEBetaGlobalNetworkEndpointGroups) List(ctx context.Context, fl *filte
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -29207,6 +29596,7 @@ func (g *GCEBetaGlobalNetworkEndpointGroups) Insert(ctx context.Context, key *me
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalNetworkEndpointGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29248,6 +29638,7 @@ func (g *GCEBetaGlobalNetworkEndpointGroups) Delete(ctx context.Context, key *me
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalNetworkEndpointGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29289,6 +29680,7 @@ func (g *GCEBetaGlobalNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.
 		Operation: "AttachNetworkEndpoints",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29331,6 +29723,7 @@ func (g *GCEBetaGlobalNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.
 		Operation: "DetachNetworkEndpoints",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29373,6 +29766,7 @@ func (g *GCEBetaGlobalNetworkEndpointGroups) ListNetworkEndpoints(ctx context.Co
 		Operation: "ListNetworkEndpoints",
 		Version:   meta.Version("beta"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaGlobalNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29652,6 +30046,7 @@ func (g *GCEGlobalNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key,
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEGlobalNetworkEndpointGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -29675,6 +30070,7 @@ func (g *GCEGlobalNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key,
 func (g *GCEGlobalNetworkEndpointGroups) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.NetworkEndpointGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEGlobalNetworkEndpointGroups.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "GlobalNetworkEndpointGroups")
 
 	ck := &CallContextKey{
@@ -29682,6 +30078,7 @@ func (g *GCEGlobalNetworkEndpointGroups) List(ctx context.Context, fl *filter.F,
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -29740,6 +30137,7 @@ func (g *GCEGlobalNetworkEndpointGroups) Insert(ctx context.Context, key *meta.K
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalNetworkEndpointGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29781,6 +30179,7 @@ func (g *GCEGlobalNetworkEndpointGroups) Delete(ctx context.Context, key *meta.K
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalNetworkEndpointGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29822,6 +30221,7 @@ func (g *GCEGlobalNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Cont
 		Operation: "AttachNetworkEndpoints",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29864,6 +30264,7 @@ func (g *GCEGlobalNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Cont
 		Operation: "DetachNetworkEndpoints",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -29906,6 +30307,7 @@ func (g *GCEGlobalNetworkEndpointGroups) ListNetworkEndpoints(ctx context.Contex
 		Operation: "ListNetworkEndpoints",
 		Version:   meta.Version("ga"),
 		Service:   "GlobalNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEGlobalNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30188,6 +30590,7 @@ func (g *GCEAlphaRegionNetworkEndpointGroups) Get(ctx context.Context, key *meta
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaRegionNetworkEndpointGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -30211,6 +30614,7 @@ func (g *GCEAlphaRegionNetworkEndpointGroups) Get(ctx context.Context, key *meta
 func (g *GCEAlphaRegionNetworkEndpointGroups) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.NetworkEndpointGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaRegionNetworkEndpointGroups.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "RegionNetworkEndpointGroups")
 
 	ck := &CallContextKey{
@@ -30218,6 +30622,7 @@ func (g *GCEAlphaRegionNetworkEndpointGroups) List(ctx context.Context, region s
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -30276,6 +30681,7 @@ func (g *GCEAlphaRegionNetworkEndpointGroups) Insert(ctx context.Context, key *m
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkEndpointGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30317,6 +30723,7 @@ func (g *GCEAlphaRegionNetworkEndpointGroups) Delete(ctx context.Context, key *m
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkEndpointGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30358,6 +30765,7 @@ func (g *GCEAlphaRegionNetworkEndpointGroups) AttachNetworkEndpoints(ctx context
 		Operation: "AttachNetworkEndpoints",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30400,6 +30808,7 @@ func (g *GCEAlphaRegionNetworkEndpointGroups) DetachNetworkEndpoints(ctx context
 		Operation: "DetachNetworkEndpoints",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30442,6 +30851,7 @@ func (g *GCEAlphaRegionNetworkEndpointGroups) ListNetworkEndpoints(ctx context.C
 		Operation: "ListNetworkEndpoints",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30724,6 +31134,7 @@ func (g *GCEBetaRegionNetworkEndpointGroups) Get(ctx context.Context, key *meta.
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaRegionNetworkEndpointGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -30747,6 +31158,7 @@ func (g *GCEBetaRegionNetworkEndpointGroups) Get(ctx context.Context, key *meta.
 func (g *GCEBetaRegionNetworkEndpointGroups) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.NetworkEndpointGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaRegionNetworkEndpointGroups.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "RegionNetworkEndpointGroups")
 
 	ck := &CallContextKey{
@@ -30754,6 +31166,7 @@ func (g *GCEBetaRegionNetworkEndpointGroups) List(ctx context.Context, region st
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -30812,6 +31225,7 @@ func (g *GCEBetaRegionNetworkEndpointGroups) Insert(ctx context.Context, key *me
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionNetworkEndpointGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30853,6 +31267,7 @@ func (g *GCEBetaRegionNetworkEndpointGroups) Delete(ctx context.Context, key *me
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionNetworkEndpointGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30894,6 +31309,7 @@ func (g *GCEBetaRegionNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.
 		Operation: "AttachNetworkEndpoints",
 		Version:   meta.Version("beta"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30936,6 +31352,7 @@ func (g *GCEBetaRegionNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.
 		Operation: "DetachNetworkEndpoints",
 		Version:   meta.Version("beta"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -30978,6 +31395,7 @@ func (g *GCEBetaRegionNetworkEndpointGroups) ListNetworkEndpoints(ctx context.Co
 		Operation: "ListNetworkEndpoints",
 		Version:   meta.Version("beta"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -31260,6 +31678,7 @@ func (g *GCERegionNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key,
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegionNetworkEndpointGroups.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -31283,6 +31702,7 @@ func (g *GCERegionNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key,
 func (g *GCERegionNetworkEndpointGroups) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.NetworkEndpointGroup, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERegionNetworkEndpointGroups.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "RegionNetworkEndpointGroups")
 
 	ck := &CallContextKey{
@@ -31290,6 +31710,7 @@ func (g *GCERegionNetworkEndpointGroups) List(ctx context.Context, region string
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -31348,6 +31769,7 @@ func (g *GCERegionNetworkEndpointGroups) Insert(ctx context.Context, key *meta.K
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionNetworkEndpointGroups.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -31389,6 +31811,7 @@ func (g *GCERegionNetworkEndpointGroups) Delete(ctx context.Context, key *meta.K
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionNetworkEndpointGroups.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -31430,6 +31853,7 @@ func (g *GCERegionNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Cont
 		Operation: "AttachNetworkEndpoints",
 		Version:   meta.Version("ga"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionNetworkEndpointGroups.AttachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -31472,6 +31896,7 @@ func (g *GCERegionNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Cont
 		Operation: "DetachNetworkEndpoints",
 		Version:   meta.Version("ga"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionNetworkEndpointGroups.DetachNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -31514,6 +31939,7 @@ func (g *GCERegionNetworkEndpointGroups) ListNetworkEndpoints(ctx context.Contex
 		Operation: "ListNetworkEndpoints",
 		Version:   meta.Version("ga"),
 		Service:   "RegionNetworkEndpointGroups",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionNetworkEndpointGroups.ListNetworkEndpoints(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -31733,6 +32159,7 @@ func (g *GCERegions) Get(ctx context.Context, key *meta.Key, options ...Option) 
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Regions",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegions.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -31756,6 +32183,7 @@ func (g *GCERegions) Get(ctx context.Context, key *meta.Key, options ...Option) 
 func (g *GCERegions) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.Region, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERegions.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Regions")
 
 	ck := &CallContextKey{
@@ -31763,6 +32191,7 @@ func (g *GCERegions) List(ctx context.Context, fl *filter.F, options ...Option) 
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Regions",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -32098,6 +32527,7 @@ func (g *GCEAlphaRouters) Get(ctx context.Context, key *meta.Key, options ...Opt
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaRouters.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -32121,6 +32551,7 @@ func (g *GCEAlphaRouters) Get(ctx context.Context, key *meta.Key, options ...Opt
 func (g *GCEAlphaRouters) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.Router, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaRouters.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "Routers")
 
 	ck := &CallContextKey{
@@ -32128,6 +32559,7 @@ func (g *GCEAlphaRouters) List(ctx context.Context, region string, fl *filter.F,
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -32186,6 +32618,7 @@ func (g *GCEAlphaRouters) Insert(ctx context.Context, key *meta.Key, obj *comput
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRouters.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -32227,6 +32660,7 @@ func (g *GCEAlphaRouters) Delete(ctx context.Context, key *meta.Key, options ...
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRouters.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -32264,6 +32698,7 @@ func (g *GCEAlphaRouters) AggregatedList(ctx context.Context, fl *filter.F, opti
 		Operation: "AggregatedList",
 		Version:   meta.Version("alpha"),
 		Service:   "Routers",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEAlphaRouters.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -32324,6 +32759,7 @@ func (g *GCEAlphaRouters) GetRouterStatus(ctx context.Context, key *meta.Key, op
 		Operation: "GetRouterStatus",
 		Version:   meta.Version("alpha"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRouters.GetRouterStatus(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -32357,6 +32793,7 @@ func (g *GCEAlphaRouters) Patch(ctx context.Context, key *meta.Key, arg0 *comput
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRouters.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -32399,6 +32836,7 @@ func (g *GCEAlphaRouters) Preview(ctx context.Context, key *meta.Key, arg0 *comp
 		Operation: "Preview",
 		Version:   meta.Version("alpha"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRouters.Preview(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -32432,6 +32870,7 @@ func (g *GCEAlphaRouters) TestIamPermissions(ctx context.Context, key *meta.Key,
 		Operation: "TestIamPermissions",
 		Version:   meta.Version("alpha"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRouters.TestIamPermissions(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -32743,6 +33182,7 @@ func (g *GCEBetaRouters) Get(ctx context.Context, key *meta.Key, options ...Opti
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaRouters.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -32766,6 +33206,7 @@ func (g *GCEBetaRouters) Get(ctx context.Context, key *meta.Key, options ...Opti
 func (g *GCEBetaRouters) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.Router, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaRouters.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "Routers")
 
 	ck := &CallContextKey{
@@ -32773,6 +33214,7 @@ func (g *GCEBetaRouters) List(ctx context.Context, region string, fl *filter.F, 
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -32831,6 +33273,7 @@ func (g *GCEBetaRouters) Insert(ctx context.Context, key *meta.Key, obj *compute
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRouters.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -32872,6 +33315,7 @@ func (g *GCEBetaRouters) Delete(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRouters.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -32909,6 +33353,7 @@ func (g *GCEBetaRouters) AggregatedList(ctx context.Context, fl *filter.F, optio
 		Operation: "AggregatedList",
 		Version:   meta.Version("beta"),
 		Service:   "Routers",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCEBetaRouters.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -32969,6 +33414,7 @@ func (g *GCEBetaRouters) GetRouterStatus(ctx context.Context, key *meta.Key, opt
 		Operation: "GetRouterStatus",
 		Version:   meta.Version("beta"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRouters.GetRouterStatus(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -33002,6 +33448,7 @@ func (g *GCEBetaRouters) Patch(ctx context.Context, key *meta.Key, arg0 *compute
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRouters.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -33044,6 +33491,7 @@ func (g *GCEBetaRouters) Preview(ctx context.Context, key *meta.Key, arg0 *compu
 		Operation: "Preview",
 		Version:   meta.Version("beta"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRouters.Preview(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -33077,6 +33525,7 @@ func (g *GCEBetaRouters) TestIamPermissions(ctx context.Context, key *meta.Key, 
 		Operation: "TestIamPermissions",
 		Version:   meta.Version("beta"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRouters.TestIamPermissions(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -33378,6 +33827,7 @@ func (g *GCERouters) Get(ctx context.Context, key *meta.Key, options ...Option) 
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERouters.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -33401,6 +33851,7 @@ func (g *GCERouters) Get(ctx context.Context, key *meta.Key, options ...Option) 
 func (g *GCERouters) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.Router, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERouters.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Routers")
 
 	ck := &CallContextKey{
@@ -33408,6 +33859,7 @@ func (g *GCERouters) List(ctx context.Context, region string, fl *filter.F, opti
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -33466,6 +33918,7 @@ func (g *GCERouters) Insert(ctx context.Context, key *meta.Key, obj *computega.R
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERouters.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -33507,6 +33960,7 @@ func (g *GCERouters) Delete(ctx context.Context, key *meta.Key, options ...Optio
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERouters.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -33544,6 +33998,7 @@ func (g *GCERouters) AggregatedList(ctx context.Context, fl *filter.F, options .
 		Operation: "AggregatedList",
 		Version:   meta.Version("ga"),
 		Service:   "Routers",
+		Resource:  &meta.Key{},
 	}
 
 	klog.V(5).Infof("GCERouters.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -33604,6 +34059,7 @@ func (g *GCERouters) GetRouterStatus(ctx context.Context, key *meta.Key, options
 		Operation: "GetRouterStatus",
 		Version:   meta.Version("ga"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERouters.GetRouterStatus(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -33637,6 +34093,7 @@ func (g *GCERouters) Patch(ctx context.Context, key *meta.Key, arg0 *computega.R
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERouters.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -33679,6 +34136,7 @@ func (g *GCERouters) Preview(ctx context.Context, key *meta.Key, arg0 *computega
 		Operation: "Preview",
 		Version:   meta.Version("ga"),
 		Service:   "Routers",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERouters.Preview(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -33909,6 +34367,7 @@ func (g *GCERoutes) Get(ctx context.Context, key *meta.Key, options ...Option) (
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Routes",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERoutes.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -33932,6 +34391,7 @@ func (g *GCERoutes) Get(ctx context.Context, key *meta.Key, options ...Option) (
 func (g *GCERoutes) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.Route, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERoutes.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Routes")
 
 	ck := &CallContextKey{
@@ -33939,6 +34399,7 @@ func (g *GCERoutes) List(ctx context.Context, fl *filter.F, options ...Option) (
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Routes",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -33997,6 +34458,7 @@ func (g *GCERoutes) Insert(ctx context.Context, key *meta.Key, obj *computega.Ro
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Routes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERoutes.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -34038,6 +34500,7 @@ func (g *GCERoutes) Delete(ctx context.Context, key *meta.Key, options ...Option
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Routes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERoutes.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -34326,6 +34789,7 @@ func (g *GCEBetaSecurityPolicies) Get(ctx context.Context, key *meta.Key, option
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "SecurityPolicies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaSecurityPolicies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -34349,6 +34813,7 @@ func (g *GCEBetaSecurityPolicies) Get(ctx context.Context, key *meta.Key, option
 func (g *GCEBetaSecurityPolicies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.SecurityPolicy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaSecurityPolicies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "SecurityPolicies")
 
 	ck := &CallContextKey{
@@ -34356,6 +34821,7 @@ func (g *GCEBetaSecurityPolicies) List(ctx context.Context, fl *filter.F, option
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "SecurityPolicies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -34414,6 +34880,7 @@ func (g *GCEBetaSecurityPolicies) Insert(ctx context.Context, key *meta.Key, obj
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "SecurityPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSecurityPolicies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -34455,6 +34922,7 @@ func (g *GCEBetaSecurityPolicies) Delete(ctx context.Context, key *meta.Key, opt
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "SecurityPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSecurityPolicies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -34496,6 +34964,7 @@ func (g *GCEBetaSecurityPolicies) AddRule(ctx context.Context, key *meta.Key, ar
 		Operation: "AddRule",
 		Version:   meta.Version("beta"),
 		Service:   "SecurityPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSecurityPolicies.AddRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -34538,6 +35007,7 @@ func (g *GCEBetaSecurityPolicies) GetRule(ctx context.Context, key *meta.Key, op
 		Operation: "GetRule",
 		Version:   meta.Version("beta"),
 		Service:   "SecurityPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSecurityPolicies.GetRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -34571,6 +35041,7 @@ func (g *GCEBetaSecurityPolicies) Patch(ctx context.Context, key *meta.Key, arg0
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "SecurityPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSecurityPolicies.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -34613,6 +35084,7 @@ func (g *GCEBetaSecurityPolicies) PatchRule(ctx context.Context, key *meta.Key, 
 		Operation: "PatchRule",
 		Version:   meta.Version("beta"),
 		Service:   "SecurityPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSecurityPolicies.PatchRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -34655,6 +35127,7 @@ func (g *GCEBetaSecurityPolicies) RemoveRule(ctx context.Context, key *meta.Key,
 		Operation: "RemoveRule",
 		Version:   meta.Version("beta"),
 		Service:   "SecurityPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSecurityPolicies.RemoveRule(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -34907,6 +35380,7 @@ func (g *GCEServiceAttachments) Get(ctx context.Context, key *meta.Key, options 
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEServiceAttachments.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -34930,6 +35404,7 @@ func (g *GCEServiceAttachments) Get(ctx context.Context, key *meta.Key, options 
 func (g *GCEServiceAttachments) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.ServiceAttachment, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEServiceAttachments.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "ServiceAttachments")
 
 	ck := &CallContextKey{
@@ -34937,6 +35412,7 @@ func (g *GCEServiceAttachments) List(ctx context.Context, region string, fl *fil
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -34995,6 +35471,7 @@ func (g *GCEServiceAttachments) Insert(ctx context.Context, key *meta.Key, obj *
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEServiceAttachments.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -35036,6 +35513,7 @@ func (g *GCEServiceAttachments) Delete(ctx context.Context, key *meta.Key, optio
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEServiceAttachments.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -35077,6 +35555,7 @@ func (g *GCEServiceAttachments) Patch(ctx context.Context, key *meta.Key, arg0 *
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEServiceAttachments.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -35329,6 +35808,7 @@ func (g *GCEBetaServiceAttachments) Get(ctx context.Context, key *meta.Key, opti
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaServiceAttachments.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -35352,6 +35832,7 @@ func (g *GCEBetaServiceAttachments) Get(ctx context.Context, key *meta.Key, opti
 func (g *GCEBetaServiceAttachments) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.ServiceAttachment, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaServiceAttachments.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "ServiceAttachments")
 
 	ck := &CallContextKey{
@@ -35359,6 +35840,7 @@ func (g *GCEBetaServiceAttachments) List(ctx context.Context, region string, fl 
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -35417,6 +35899,7 @@ func (g *GCEBetaServiceAttachments) Insert(ctx context.Context, key *meta.Key, o
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaServiceAttachments.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -35458,6 +35941,7 @@ func (g *GCEBetaServiceAttachments) Delete(ctx context.Context, key *meta.Key, o
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaServiceAttachments.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -35499,6 +35983,7 @@ func (g *GCEBetaServiceAttachments) Patch(ctx context.Context, key *meta.Key, ar
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaServiceAttachments.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -35751,6 +36236,7 @@ func (g *GCEAlphaServiceAttachments) Get(ctx context.Context, key *meta.Key, opt
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaServiceAttachments.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -35774,6 +36260,7 @@ func (g *GCEAlphaServiceAttachments) Get(ctx context.Context, key *meta.Key, opt
 func (g *GCEAlphaServiceAttachments) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.ServiceAttachment, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaServiceAttachments.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "ServiceAttachments")
 
 	ck := &CallContextKey{
@@ -35781,6 +36268,7 @@ func (g *GCEAlphaServiceAttachments) List(ctx context.Context, region string, fl
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -35839,6 +36327,7 @@ func (g *GCEAlphaServiceAttachments) Insert(ctx context.Context, key *meta.Key, 
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaServiceAttachments.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -35880,6 +36369,7 @@ func (g *GCEAlphaServiceAttachments) Delete(ctx context.Context, key *meta.Key, 
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaServiceAttachments.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -35921,6 +36411,7 @@ func (g *GCEAlphaServiceAttachments) Patch(ctx context.Context, key *meta.Key, a
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "ServiceAttachments",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaServiceAttachments.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -36160,6 +36651,7 @@ func (g *GCESslCertificates) Get(ctx context.Context, key *meta.Key, options ...
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCESslCertificates.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -36183,6 +36675,7 @@ func (g *GCESslCertificates) Get(ctx context.Context, key *meta.Key, options ...
 func (g *GCESslCertificates) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.SslCertificate, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCESslCertificates.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "SslCertificates")
 
 	ck := &CallContextKey{
@@ -36190,6 +36683,7 @@ func (g *GCESslCertificates) List(ctx context.Context, fl *filter.F, options ...
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -36248,6 +36742,7 @@ func (g *GCESslCertificates) Insert(ctx context.Context, key *meta.Key, obj *com
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCESslCertificates.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -36289,6 +36784,7 @@ func (g *GCESslCertificates) Delete(ctx context.Context, key *meta.Key, options 
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCESslCertificates.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -36527,6 +37023,7 @@ func (g *GCEBetaSslCertificates) Get(ctx context.Context, key *meta.Key, options
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaSslCertificates.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -36550,6 +37047,7 @@ func (g *GCEBetaSslCertificates) Get(ctx context.Context, key *meta.Key, options
 func (g *GCEBetaSslCertificates) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.SslCertificate, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaSslCertificates.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "SslCertificates")
 
 	ck := &CallContextKey{
@@ -36557,6 +37055,7 @@ func (g *GCEBetaSslCertificates) List(ctx context.Context, fl *filter.F, options
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -36615,6 +37114,7 @@ func (g *GCEBetaSslCertificates) Insert(ctx context.Context, key *meta.Key, obj 
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSslCertificates.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -36656,6 +37156,7 @@ func (g *GCEBetaSslCertificates) Delete(ctx context.Context, key *meta.Key, opti
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSslCertificates.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -36894,6 +37395,7 @@ func (g *GCEAlphaSslCertificates) Get(ctx context.Context, key *meta.Key, option
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaSslCertificates.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -36917,6 +37419,7 @@ func (g *GCEAlphaSslCertificates) Get(ctx context.Context, key *meta.Key, option
 func (g *GCEAlphaSslCertificates) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.SslCertificate, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaSslCertificates.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "SslCertificates")
 
 	ck := &CallContextKey{
@@ -36924,6 +37427,7 @@ func (g *GCEAlphaSslCertificates) List(ctx context.Context, fl *filter.F, option
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -36982,6 +37486,7 @@ func (g *GCEAlphaSslCertificates) Insert(ctx context.Context, key *meta.Key, obj
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaSslCertificates.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -37023,6 +37528,7 @@ func (g *GCEAlphaSslCertificates) Delete(ctx context.Context, key *meta.Key, opt
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "SslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaSslCertificates.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -37264,6 +37770,7 @@ func (g *GCEAlphaRegionSslCertificates) Get(ctx context.Context, key *meta.Key, 
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaRegionSslCertificates.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -37287,6 +37794,7 @@ func (g *GCEAlphaRegionSslCertificates) Get(ctx context.Context, key *meta.Key, 
 func (g *GCEAlphaRegionSslCertificates) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.SslCertificate, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaRegionSslCertificates.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "RegionSslCertificates")
 
 	ck := &CallContextKey{
@@ -37294,6 +37802,7 @@ func (g *GCEAlphaRegionSslCertificates) List(ctx context.Context, region string,
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -37352,6 +37861,7 @@ func (g *GCEAlphaRegionSslCertificates) Insert(ctx context.Context, key *meta.Ke
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionSslCertificates.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -37393,6 +37903,7 @@ func (g *GCEAlphaRegionSslCertificates) Delete(ctx context.Context, key *meta.Ke
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionSslCertificates.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -37634,6 +38145,7 @@ func (g *GCEBetaRegionSslCertificates) Get(ctx context.Context, key *meta.Key, o
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaRegionSslCertificates.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -37657,6 +38169,7 @@ func (g *GCEBetaRegionSslCertificates) Get(ctx context.Context, key *meta.Key, o
 func (g *GCEBetaRegionSslCertificates) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.SslCertificate, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaRegionSslCertificates.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "RegionSslCertificates")
 
 	ck := &CallContextKey{
@@ -37664,6 +38177,7 @@ func (g *GCEBetaRegionSslCertificates) List(ctx context.Context, region string, 
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -37722,6 +38236,7 @@ func (g *GCEBetaRegionSslCertificates) Insert(ctx context.Context, key *meta.Key
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionSslCertificates.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -37763,6 +38278,7 @@ func (g *GCEBetaRegionSslCertificates) Delete(ctx context.Context, key *meta.Key
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionSslCertificates.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -38004,6 +38520,7 @@ func (g *GCERegionSslCertificates) Get(ctx context.Context, key *meta.Key, optio
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegionSslCertificates.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -38027,6 +38544,7 @@ func (g *GCERegionSslCertificates) Get(ctx context.Context, key *meta.Key, optio
 func (g *GCERegionSslCertificates) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.SslCertificate, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERegionSslCertificates.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "RegionSslCertificates")
 
 	ck := &CallContextKey{
@@ -38034,6 +38552,7 @@ func (g *GCERegionSslCertificates) List(ctx context.Context, region string, fl *
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -38092,6 +38611,7 @@ func (g *GCERegionSslCertificates) Insert(ctx context.Context, key *meta.Key, ob
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionSslCertificates.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -38133,6 +38653,7 @@ func (g *GCERegionSslCertificates) Delete(ctx context.Context, key *meta.Key, op
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "RegionSslCertificates",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionSslCertificates.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -38337,6 +38858,7 @@ func (g *GCESslPolicies) Get(ctx context.Context, key *meta.Key, options ...Opti
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "SslPolicies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCESslPolicies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -38372,6 +38894,7 @@ func (g *GCESslPolicies) Insert(ctx context.Context, key *meta.Key, obj *compute
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "SslPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCESslPolicies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -38413,6 +38936,7 @@ func (g *GCESslPolicies) Delete(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "SslPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCESslPolicies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -38617,6 +39141,7 @@ func (g *GCERegionSslPolicies) Get(ctx context.Context, key *meta.Key, options .
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "RegionSslPolicies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegionSslPolicies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -38652,6 +39177,7 @@ func (g *GCERegionSslPolicies) Insert(ctx context.Context, key *meta.Key, obj *c
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "RegionSslPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionSslPolicies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -38693,6 +39219,7 @@ func (g *GCERegionSslPolicies) Delete(ctx context.Context, key *meta.Key, option
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "RegionSslPolicies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionSslPolicies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -38983,6 +39510,7 @@ func (g *GCEAlphaSubnetworks) Get(ctx context.Context, key *meta.Key, options ..
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaSubnetworks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -39006,6 +39534,7 @@ func (g *GCEAlphaSubnetworks) Get(ctx context.Context, key *meta.Key, options ..
 func (g *GCEAlphaSubnetworks) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.Subnetwork, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaSubnetworks.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "Subnetworks")
 
 	ck := &CallContextKey{
@@ -39013,6 +39542,7 @@ func (g *GCEAlphaSubnetworks) List(ctx context.Context, region string, fl *filte
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -39071,6 +39601,7 @@ func (g *GCEAlphaSubnetworks) Insert(ctx context.Context, key *meta.Key, obj *co
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaSubnetworks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -39112,6 +39643,7 @@ func (g *GCEAlphaSubnetworks) Delete(ctx context.Context, key *meta.Key, options
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaSubnetworks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -39148,6 +39680,7 @@ func (g *GCEAlphaSubnetworks) ListUsable(ctx context.Context, fl *filter.F, opti
 		Operation: "ListUsable",
 		Version:   meta.Version("alpha"),
 		Service:   "Subnetworks",
+		Resource:  &meta.Key{},
 	}
 	callObserverStart(ctx, ck)
 	if err := g.s.RateLimiter.Accept(ctx, ck); err != nil {
@@ -39203,6 +39736,7 @@ func (g *GCEAlphaSubnetworks) Patch(ctx context.Context, key *meta.Key, arg0 *co
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaSubnetworks.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -39494,6 +40028,7 @@ func (g *GCEBetaSubnetworks) Get(ctx context.Context, key *meta.Key, options ...
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaSubnetworks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -39517,6 +40052,7 @@ func (g *GCEBetaSubnetworks) Get(ctx context.Context, key *meta.Key, options ...
 func (g *GCEBetaSubnetworks) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.Subnetwork, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaSubnetworks.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "Subnetworks")
 
 	ck := &CallContextKey{
@@ -39524,6 +40060,7 @@ func (g *GCEBetaSubnetworks) List(ctx context.Context, region string, fl *filter
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -39582,6 +40119,7 @@ func (g *GCEBetaSubnetworks) Insert(ctx context.Context, key *meta.Key, obj *com
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSubnetworks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -39623,6 +40161,7 @@ func (g *GCEBetaSubnetworks) Delete(ctx context.Context, key *meta.Key, options 
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSubnetworks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -39659,6 +40198,7 @@ func (g *GCEBetaSubnetworks) ListUsable(ctx context.Context, fl *filter.F, optio
 		Operation: "ListUsable",
 		Version:   meta.Version("beta"),
 		Service:   "Subnetworks",
+		Resource:  &meta.Key{},
 	}
 	callObserverStart(ctx, ck)
 	if err := g.s.RateLimiter.Accept(ctx, ck); err != nil {
@@ -39714,6 +40254,7 @@ func (g *GCEBetaSubnetworks) Patch(ctx context.Context, key *meta.Key, arg0 *com
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaSubnetworks.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -40005,6 +40546,7 @@ func (g *GCESubnetworks) Get(ctx context.Context, key *meta.Key, options ...Opti
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCESubnetworks.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -40028,6 +40570,7 @@ func (g *GCESubnetworks) Get(ctx context.Context, key *meta.Key, options ...Opti
 func (g *GCESubnetworks) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.Subnetwork, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCESubnetworks.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Subnetworks")
 
 	ck := &CallContextKey{
@@ -40035,6 +40578,7 @@ func (g *GCESubnetworks) List(ctx context.Context, region string, fl *filter.F, 
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -40093,6 +40637,7 @@ func (g *GCESubnetworks) Insert(ctx context.Context, key *meta.Key, obj *compute
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCESubnetworks.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -40134,6 +40679,7 @@ func (g *GCESubnetworks) Delete(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCESubnetworks.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -40170,6 +40716,7 @@ func (g *GCESubnetworks) ListUsable(ctx context.Context, fl *filter.F, options .
 		Operation: "ListUsable",
 		Version:   meta.Version("ga"),
 		Service:   "Subnetworks",
+		Resource:  &meta.Key{},
 	}
 	callObserverStart(ctx, ck)
 	if err := g.s.RateLimiter.Accept(ctx, ck); err != nil {
@@ -40225,6 +40772,7 @@ func (g *GCESubnetworks) Patch(ctx context.Context, key *meta.Key, arg0 *compute
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "Subnetworks",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCESubnetworks.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -40474,6 +41022,7 @@ func (g *GCEAlphaTargetHttpProxies) Get(ctx context.Context, key *meta.Key, opti
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaTargetHttpProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -40497,6 +41046,7 @@ func (g *GCEAlphaTargetHttpProxies) Get(ctx context.Context, key *meta.Key, opti
 func (g *GCEAlphaTargetHttpProxies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.TargetHttpProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaTargetHttpProxies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "TargetHttpProxies")
 
 	ck := &CallContextKey{
@@ -40504,6 +41054,7 @@ func (g *GCEAlphaTargetHttpProxies) List(ctx context.Context, fl *filter.F, opti
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -40562,6 +41113,7 @@ func (g *GCEAlphaTargetHttpProxies) Insert(ctx context.Context, key *meta.Key, o
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetHttpProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -40603,6 +41155,7 @@ func (g *GCEAlphaTargetHttpProxies) Delete(ctx context.Context, key *meta.Key, o
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetHttpProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -40644,6 +41197,7 @@ func (g *GCEAlphaTargetHttpProxies) SetUrlMap(ctx context.Context, key *meta.Key
 		Operation: "SetUrlMap",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetHttpProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -40893,6 +41447,7 @@ func (g *GCEBetaTargetHttpProxies) Get(ctx context.Context, key *meta.Key, optio
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaTargetHttpProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -40916,6 +41471,7 @@ func (g *GCEBetaTargetHttpProxies) Get(ctx context.Context, key *meta.Key, optio
 func (g *GCEBetaTargetHttpProxies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.TargetHttpProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaTargetHttpProxies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "TargetHttpProxies")
 
 	ck := &CallContextKey{
@@ -40923,6 +41479,7 @@ func (g *GCEBetaTargetHttpProxies) List(ctx context.Context, fl *filter.F, optio
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -40981,6 +41538,7 @@ func (g *GCEBetaTargetHttpProxies) Insert(ctx context.Context, key *meta.Key, ob
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetHttpProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -41022,6 +41580,7 @@ func (g *GCEBetaTargetHttpProxies) Delete(ctx context.Context, key *meta.Key, op
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetHttpProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -41063,6 +41622,7 @@ func (g *GCEBetaTargetHttpProxies) SetUrlMap(ctx context.Context, key *meta.Key,
 		Operation: "SetUrlMap",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetHttpProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -41312,6 +41872,7 @@ func (g *GCETargetHttpProxies) Get(ctx context.Context, key *meta.Key, options .
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCETargetHttpProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -41335,6 +41896,7 @@ func (g *GCETargetHttpProxies) Get(ctx context.Context, key *meta.Key, options .
 func (g *GCETargetHttpProxies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.TargetHttpProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCETargetHttpProxies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "TargetHttpProxies")
 
 	ck := &CallContextKey{
@@ -41342,6 +41904,7 @@ func (g *GCETargetHttpProxies) List(ctx context.Context, fl *filter.F, options .
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -41400,6 +41963,7 @@ func (g *GCETargetHttpProxies) Insert(ctx context.Context, key *meta.Key, obj *c
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetHttpProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -41441,6 +42005,7 @@ func (g *GCETargetHttpProxies) Delete(ctx context.Context, key *meta.Key, option
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetHttpProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -41482,6 +42047,7 @@ func (g *GCETargetHttpProxies) SetUrlMap(ctx context.Context, key *meta.Key, arg
 		Operation: "SetUrlMap",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetHttpProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -41734,6 +42300,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) Get(ctx context.Context, key *meta.Key
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -41757,6 +42324,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) Get(ctx context.Context, key *meta.Key
 func (g *GCEAlphaRegionTargetHttpProxies) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.TargetHttpProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpProxies.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "RegionTargetHttpProxies")
 
 	ck := &CallContextKey{
@@ -41764,6 +42332,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) List(ctx context.Context, region strin
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -41822,6 +42391,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) Insert(ctx context.Context, key *meta.
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -41863,6 +42433,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) Delete(ctx context.Context, key *meta.
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -41904,6 +42475,7 @@ func (g *GCEAlphaRegionTargetHttpProxies) SetUrlMap(ctx context.Context, key *me
 		Operation: "SetUrlMap",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -42156,6 +42728,7 @@ func (g *GCEBetaRegionTargetHttpProxies) Get(ctx context.Context, key *meta.Key,
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaRegionTargetHttpProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -42179,6 +42752,7 @@ func (g *GCEBetaRegionTargetHttpProxies) Get(ctx context.Context, key *meta.Key,
 func (g *GCEBetaRegionTargetHttpProxies) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.TargetHttpProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaRegionTargetHttpProxies.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "RegionTargetHttpProxies")
 
 	ck := &CallContextKey{
@@ -42186,6 +42760,7 @@ func (g *GCEBetaRegionTargetHttpProxies) List(ctx context.Context, region string
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -42244,6 +42819,7 @@ func (g *GCEBetaRegionTargetHttpProxies) Insert(ctx context.Context, key *meta.K
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionTargetHttpProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -42285,6 +42861,7 @@ func (g *GCEBetaRegionTargetHttpProxies) Delete(ctx context.Context, key *meta.K
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionTargetHttpProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -42326,6 +42903,7 @@ func (g *GCEBetaRegionTargetHttpProxies) SetUrlMap(ctx context.Context, key *met
 		Operation: "SetUrlMap",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionTargetHttpProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -42578,6 +43156,7 @@ func (g *GCERegionTargetHttpProxies) Get(ctx context.Context, key *meta.Key, opt
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegionTargetHttpProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -42601,6 +43180,7 @@ func (g *GCERegionTargetHttpProxies) Get(ctx context.Context, key *meta.Key, opt
 func (g *GCERegionTargetHttpProxies) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.TargetHttpProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERegionTargetHttpProxies.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "RegionTargetHttpProxies")
 
 	ck := &CallContextKey{
@@ -42608,6 +43188,7 @@ func (g *GCERegionTargetHttpProxies) List(ctx context.Context, region string, fl
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -42666,6 +43247,7 @@ func (g *GCERegionTargetHttpProxies) Insert(ctx context.Context, key *meta.Key, 
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionTargetHttpProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -42707,6 +43289,7 @@ func (g *GCERegionTargetHttpProxies) Delete(ctx context.Context, key *meta.Key, 
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionTargetHttpProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -42748,6 +43331,7 @@ func (g *GCERegionTargetHttpProxies) SetUrlMap(ctx context.Context, key *meta.Ke
 		Operation: "SetUrlMap",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionTargetHttpProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43027,6 +43611,7 @@ func (g *GCETargetHttpsProxies) Get(ctx context.Context, key *meta.Key, options 
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCETargetHttpsProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -43050,6 +43635,7 @@ func (g *GCETargetHttpsProxies) Get(ctx context.Context, key *meta.Key, options 
 func (g *GCETargetHttpsProxies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.TargetHttpsProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCETargetHttpsProxies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "TargetHttpsProxies")
 
 	ck := &CallContextKey{
@@ -43057,6 +43643,7 @@ func (g *GCETargetHttpsProxies) List(ctx context.Context, fl *filter.F, options 
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -43115,6 +43702,7 @@ func (g *GCETargetHttpsProxies) Insert(ctx context.Context, key *meta.Key, obj *
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetHttpsProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43156,6 +43744,7 @@ func (g *GCETargetHttpsProxies) Delete(ctx context.Context, key *meta.Key, optio
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetHttpsProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43197,6 +43786,7 @@ func (g *GCETargetHttpsProxies) SetCertificateMap(ctx context.Context, key *meta
 		Operation: "SetCertificateMap",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetHttpsProxies.SetCertificateMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43239,6 +43829,7 @@ func (g *GCETargetHttpsProxies) SetSslCertificates(ctx context.Context, key *met
 		Operation: "SetSslCertificates",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetHttpsProxies.SetSslCertificates(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43281,6 +43872,7 @@ func (g *GCETargetHttpsProxies) SetSslPolicy(ctx context.Context, key *meta.Key,
 		Operation: "SetSslPolicy",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetHttpsProxies.SetSslPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43323,6 +43915,7 @@ func (g *GCETargetHttpsProxies) SetUrlMap(ctx context.Context, key *meta.Key, ar
 		Operation: "SetUrlMap",
 		Version:   meta.Version("ga"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetHttpsProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43602,6 +44195,7 @@ func (g *GCEAlphaTargetHttpsProxies) Get(ctx context.Context, key *meta.Key, opt
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaTargetHttpsProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -43625,6 +44219,7 @@ func (g *GCEAlphaTargetHttpsProxies) Get(ctx context.Context, key *meta.Key, opt
 func (g *GCEAlphaTargetHttpsProxies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.TargetHttpsProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaTargetHttpsProxies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "TargetHttpsProxies")
 
 	ck := &CallContextKey{
@@ -43632,6 +44227,7 @@ func (g *GCEAlphaTargetHttpsProxies) List(ctx context.Context, fl *filter.F, opt
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -43690,6 +44286,7 @@ func (g *GCEAlphaTargetHttpsProxies) Insert(ctx context.Context, key *meta.Key, 
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetHttpsProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43731,6 +44328,7 @@ func (g *GCEAlphaTargetHttpsProxies) Delete(ctx context.Context, key *meta.Key, 
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetHttpsProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43772,6 +44370,7 @@ func (g *GCEAlphaTargetHttpsProxies) SetCertificateMap(ctx context.Context, key 
 		Operation: "SetCertificateMap",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetHttpsProxies.SetCertificateMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43814,6 +44413,7 @@ func (g *GCEAlphaTargetHttpsProxies) SetSslCertificates(ctx context.Context, key
 		Operation: "SetSslCertificates",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetHttpsProxies.SetSslCertificates(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43856,6 +44456,7 @@ func (g *GCEAlphaTargetHttpsProxies) SetSslPolicy(ctx context.Context, key *meta
 		Operation: "SetSslPolicy",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetHttpsProxies.SetSslPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -43898,6 +44499,7 @@ func (g *GCEAlphaTargetHttpsProxies) SetUrlMap(ctx context.Context, key *meta.Ke
 		Operation: "SetUrlMap",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetHttpsProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44177,6 +44779,7 @@ func (g *GCEBetaTargetHttpsProxies) Get(ctx context.Context, key *meta.Key, opti
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaTargetHttpsProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -44200,6 +44803,7 @@ func (g *GCEBetaTargetHttpsProxies) Get(ctx context.Context, key *meta.Key, opti
 func (g *GCEBetaTargetHttpsProxies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.TargetHttpsProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaTargetHttpsProxies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "TargetHttpsProxies")
 
 	ck := &CallContextKey{
@@ -44207,6 +44811,7 @@ func (g *GCEBetaTargetHttpsProxies) List(ctx context.Context, fl *filter.F, opti
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -44265,6 +44870,7 @@ func (g *GCEBetaTargetHttpsProxies) Insert(ctx context.Context, key *meta.Key, o
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetHttpsProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44306,6 +44912,7 @@ func (g *GCEBetaTargetHttpsProxies) Delete(ctx context.Context, key *meta.Key, o
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetHttpsProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44347,6 +44954,7 @@ func (g *GCEBetaTargetHttpsProxies) SetCertificateMap(ctx context.Context, key *
 		Operation: "SetCertificateMap",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetHttpsProxies.SetCertificateMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44389,6 +44997,7 @@ func (g *GCEBetaTargetHttpsProxies) SetSslCertificates(ctx context.Context, key 
 		Operation: "SetSslCertificates",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetHttpsProxies.SetSslCertificates(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44431,6 +45040,7 @@ func (g *GCEBetaTargetHttpsProxies) SetSslPolicy(ctx context.Context, key *meta.
 		Operation: "SetSslPolicy",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetHttpsProxies.SetSslPolicy(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44473,6 +45083,7 @@ func (g *GCEBetaTargetHttpsProxies) SetUrlMap(ctx context.Context, key *meta.Key
 		Operation: "SetUrlMap",
 		Version:   meta.Version("beta"),
 		Service:   "TargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetHttpsProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44745,6 +45356,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) Get(ctx context.Context, key *meta.Ke
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpsProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -44768,6 +45380,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) Get(ctx context.Context, key *meta.Ke
 func (g *GCEAlphaRegionTargetHttpsProxies) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.TargetHttpsProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpsProxies.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "RegionTargetHttpsProxies")
 
 	ck := &CallContextKey{
@@ -44775,6 +45388,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) List(ctx context.Context, region stri
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -44833,6 +45447,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) Insert(ctx context.Context, key *meta
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpsProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44874,6 +45489,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) Delete(ctx context.Context, key *meta
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpsProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44915,6 +45531,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) Patch(ctx context.Context, key *meta.
 		Operation: "Patch",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpsProxies.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44957,6 +45574,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) SetSslCertificates(ctx context.Contex
 		Operation: "SetSslCertificates",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpsProxies.SetSslCertificates(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -44999,6 +45617,7 @@ func (g *GCEAlphaRegionTargetHttpsProxies) SetUrlMap(ctx context.Context, key *m
 		Operation: "SetUrlMap",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionTargetHttpsProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -45271,6 +45890,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) Get(ctx context.Context, key *meta.Key
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaRegionTargetHttpsProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -45294,6 +45914,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) Get(ctx context.Context, key *meta.Key
 func (g *GCEBetaRegionTargetHttpsProxies) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.TargetHttpsProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaRegionTargetHttpsProxies.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "RegionTargetHttpsProxies")
 
 	ck := &CallContextKey{
@@ -45301,6 +45922,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) List(ctx context.Context, region strin
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -45359,6 +45981,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) Insert(ctx context.Context, key *meta.
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionTargetHttpsProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -45400,6 +46023,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) Delete(ctx context.Context, key *meta.
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionTargetHttpsProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -45441,6 +46065,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) Patch(ctx context.Context, key *meta.K
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionTargetHttpsProxies.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -45483,6 +46108,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) SetSslCertificates(ctx context.Context
 		Operation: "SetSslCertificates",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionTargetHttpsProxies.SetSslCertificates(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -45525,6 +46151,7 @@ func (g *GCEBetaRegionTargetHttpsProxies) SetUrlMap(ctx context.Context, key *me
 		Operation: "SetUrlMap",
 		Version:   meta.Version("beta"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionTargetHttpsProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -45797,6 +46424,7 @@ func (g *GCERegionTargetHttpsProxies) Get(ctx context.Context, key *meta.Key, op
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegionTargetHttpsProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -45820,6 +46448,7 @@ func (g *GCERegionTargetHttpsProxies) Get(ctx context.Context, key *meta.Key, op
 func (g *GCERegionTargetHttpsProxies) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.TargetHttpsProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERegionTargetHttpsProxies.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "RegionTargetHttpsProxies")
 
 	ck := &CallContextKey{
@@ -45827,6 +46456,7 @@ func (g *GCERegionTargetHttpsProxies) List(ctx context.Context, region string, f
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -45885,6 +46515,7 @@ func (g *GCERegionTargetHttpsProxies) Insert(ctx context.Context, key *meta.Key,
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionTargetHttpsProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -45926,6 +46557,7 @@ func (g *GCERegionTargetHttpsProxies) Delete(ctx context.Context, key *meta.Key,
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionTargetHttpsProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -45967,6 +46599,7 @@ func (g *GCERegionTargetHttpsProxies) Patch(ctx context.Context, key *meta.Key, 
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionTargetHttpsProxies.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -46009,6 +46642,7 @@ func (g *GCERegionTargetHttpsProxies) SetSslCertificates(ctx context.Context, ke
 		Operation: "SetSslCertificates",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionTargetHttpsProxies.SetSslCertificates(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -46051,6 +46685,7 @@ func (g *GCERegionTargetHttpsProxies) SetUrlMap(ctx context.Context, key *meta.K
 		Operation: "SetUrlMap",
 		Version:   meta.Version("ga"),
 		Service:   "RegionTargetHttpsProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionTargetHttpsProxies.SetUrlMap(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -46313,6 +46948,7 @@ func (g *GCETargetPools) Get(ctx context.Context, key *meta.Key, options ...Opti
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "TargetPools",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCETargetPools.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -46336,6 +46972,7 @@ func (g *GCETargetPools) Get(ctx context.Context, key *meta.Key, options ...Opti
 func (g *GCETargetPools) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.TargetPool, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCETargetPools.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "TargetPools")
 
 	ck := &CallContextKey{
@@ -46343,6 +46980,7 @@ func (g *GCETargetPools) List(ctx context.Context, region string, fl *filter.F, 
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "TargetPools",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -46401,6 +47039,7 @@ func (g *GCETargetPools) Insert(ctx context.Context, key *meta.Key, obj *compute
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "TargetPools",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetPools.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -46442,6 +47081,7 @@ func (g *GCETargetPools) Delete(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "TargetPools",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetPools.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -46483,6 +47123,7 @@ func (g *GCETargetPools) AddInstance(ctx context.Context, key *meta.Key, arg0 *c
 		Operation: "AddInstance",
 		Version:   meta.Version("ga"),
 		Service:   "TargetPools",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetPools.AddInstance(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -46525,6 +47166,7 @@ func (g *GCETargetPools) RemoveInstance(ctx context.Context, key *meta.Key, arg0
 		Operation: "RemoveInstance",
 		Version:   meta.Version("ga"),
 		Service:   "TargetPools",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetPools.RemoveInstance(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -46774,6 +47416,7 @@ func (g *GCEAlphaTargetTcpProxies) Get(ctx context.Context, key *meta.Key, optio
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaTargetTcpProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -46797,6 +47440,7 @@ func (g *GCEAlphaTargetTcpProxies) Get(ctx context.Context, key *meta.Key, optio
 func (g *GCEAlphaTargetTcpProxies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.TargetTcpProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaTargetTcpProxies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "TargetTcpProxies")
 
 	ck := &CallContextKey{
@@ -46804,6 +47448,7 @@ func (g *GCEAlphaTargetTcpProxies) List(ctx context.Context, fl *filter.F, optio
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -46862,6 +47507,7 @@ func (g *GCEAlphaTargetTcpProxies) Insert(ctx context.Context, key *meta.Key, ob
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetTcpProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -46903,6 +47549,7 @@ func (g *GCEAlphaTargetTcpProxies) Delete(ctx context.Context, key *meta.Key, op
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetTcpProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -46944,6 +47591,7 @@ func (g *GCEAlphaTargetTcpProxies) SetBackendService(ctx context.Context, key *m
 		Operation: "SetBackendService",
 		Version:   meta.Version("alpha"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaTargetTcpProxies.SetBackendService(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -47193,6 +47841,7 @@ func (g *GCEBetaTargetTcpProxies) Get(ctx context.Context, key *meta.Key, option
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaTargetTcpProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -47216,6 +47865,7 @@ func (g *GCEBetaTargetTcpProxies) Get(ctx context.Context, key *meta.Key, option
 func (g *GCEBetaTargetTcpProxies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.TargetTcpProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaTargetTcpProxies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "TargetTcpProxies")
 
 	ck := &CallContextKey{
@@ -47223,6 +47873,7 @@ func (g *GCEBetaTargetTcpProxies) List(ctx context.Context, fl *filter.F, option
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -47281,6 +47932,7 @@ func (g *GCEBetaTargetTcpProxies) Insert(ctx context.Context, key *meta.Key, obj
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetTcpProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -47322,6 +47974,7 @@ func (g *GCEBetaTargetTcpProxies) Delete(ctx context.Context, key *meta.Key, opt
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetTcpProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -47363,6 +48016,7 @@ func (g *GCEBetaTargetTcpProxies) SetBackendService(ctx context.Context, key *me
 		Operation: "SetBackendService",
 		Version:   meta.Version("beta"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaTargetTcpProxies.SetBackendService(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -47612,6 +48266,7 @@ func (g *GCETargetTcpProxies) Get(ctx context.Context, key *meta.Key, options ..
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCETargetTcpProxies.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -47635,6 +48290,7 @@ func (g *GCETargetTcpProxies) Get(ctx context.Context, key *meta.Key, options ..
 func (g *GCETargetTcpProxies) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.TargetTcpProxy, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCETargetTcpProxies.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "TargetTcpProxies")
 
 	ck := &CallContextKey{
@@ -47642,6 +48298,7 @@ func (g *GCETargetTcpProxies) List(ctx context.Context, fl *filter.F, options ..
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -47700,6 +48357,7 @@ func (g *GCETargetTcpProxies) Insert(ctx context.Context, key *meta.Key, obj *co
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetTcpProxies.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -47741,6 +48399,7 @@ func (g *GCETargetTcpProxies) Delete(ctx context.Context, key *meta.Key, options
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetTcpProxies.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -47782,6 +48441,7 @@ func (g *GCETargetTcpProxies) SetBackendService(ctx context.Context, key *meta.K
 		Operation: "SetBackendService",
 		Version:   meta.Version("ga"),
 		Service:   "TargetTcpProxies",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCETargetTcpProxies.SetBackendService(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -48031,6 +48691,7 @@ func (g *GCEAlphaUrlMaps) Get(ctx context.Context, key *meta.Key, options ...Opt
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaUrlMaps.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -48054,6 +48715,7 @@ func (g *GCEAlphaUrlMaps) Get(ctx context.Context, key *meta.Key, options ...Opt
 func (g *GCEAlphaUrlMaps) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computealpha.UrlMap, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaUrlMaps.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "UrlMaps")
 
 	ck := &CallContextKey{
@@ -48061,6 +48723,7 @@ func (g *GCEAlphaUrlMaps) List(ctx context.Context, fl *filter.F, options ...Opt
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -48119,6 +48782,7 @@ func (g *GCEAlphaUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *comput
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaUrlMaps.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -48160,6 +48824,7 @@ func (g *GCEAlphaUrlMaps) Delete(ctx context.Context, key *meta.Key, options ...
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaUrlMaps.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -48201,6 +48866,7 @@ func (g *GCEAlphaUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *compu
 		Operation: "Update",
 		Version:   meta.Version("alpha"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaUrlMaps.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -48450,6 +49116,7 @@ func (g *GCEBetaUrlMaps) Get(ctx context.Context, key *meta.Key, options ...Opti
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaUrlMaps.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -48473,6 +49140,7 @@ func (g *GCEBetaUrlMaps) Get(ctx context.Context, key *meta.Key, options ...Opti
 func (g *GCEBetaUrlMaps) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computebeta.UrlMap, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaUrlMaps.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "UrlMaps")
 
 	ck := &CallContextKey{
@@ -48480,6 +49148,7 @@ func (g *GCEBetaUrlMaps) List(ctx context.Context, fl *filter.F, options ...Opti
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -48538,6 +49207,7 @@ func (g *GCEBetaUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *compute
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaUrlMaps.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -48579,6 +49249,7 @@ func (g *GCEBetaUrlMaps) Delete(ctx context.Context, key *meta.Key, options ...O
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaUrlMaps.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -48620,6 +49291,7 @@ func (g *GCEBetaUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *comput
 		Operation: "Update",
 		Version:   meta.Version("beta"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaUrlMaps.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -48869,6 +49541,7 @@ func (g *GCEUrlMaps) Get(ctx context.Context, key *meta.Key, options ...Option) 
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEUrlMaps.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -48892,6 +49565,7 @@ func (g *GCEUrlMaps) Get(ctx context.Context, key *meta.Key, options ...Option) 
 func (g *GCEUrlMaps) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.UrlMap, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEUrlMaps.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "UrlMaps")
 
 	ck := &CallContextKey{
@@ -48899,6 +49573,7 @@ func (g *GCEUrlMaps) List(ctx context.Context, fl *filter.F, options ...Option) 
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -48957,6 +49632,7 @@ func (g *GCEUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *computega.U
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEUrlMaps.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -48998,6 +49674,7 @@ func (g *GCEUrlMaps) Delete(ctx context.Context, key *meta.Key, options ...Optio
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEUrlMaps.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -49039,6 +49716,7 @@ func (g *GCEUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *computega.
 		Operation: "Update",
 		Version:   meta.Version("ga"),
 		Service:   "UrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEUrlMaps.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -49291,6 +49969,7 @@ func (g *GCEAlphaRegionUrlMaps) Get(ctx context.Context, key *meta.Key, options 
 		Operation: "Get",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEAlphaRegionUrlMaps.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -49314,6 +49993,7 @@ func (g *GCEAlphaRegionUrlMaps) Get(ctx context.Context, key *meta.Key, options 
 func (g *GCEAlphaRegionUrlMaps) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computealpha.UrlMap, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEAlphaRegionUrlMaps.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "alpha", "RegionUrlMaps")
 
 	ck := &CallContextKey{
@@ -49321,6 +50001,7 @@ func (g *GCEAlphaRegionUrlMaps) List(ctx context.Context, region string, fl *fil
 		Operation: "List",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -49379,6 +50060,7 @@ func (g *GCEAlphaRegionUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *
 		Operation: "Insert",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionUrlMaps.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -49420,6 +50102,7 @@ func (g *GCEAlphaRegionUrlMaps) Delete(ctx context.Context, key *meta.Key, optio
 		Operation: "Delete",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionUrlMaps.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -49461,6 +50144,7 @@ func (g *GCEAlphaRegionUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 
 		Operation: "Update",
 		Version:   meta.Version("alpha"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEAlphaRegionUrlMaps.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -49713,6 +50397,7 @@ func (g *GCEBetaRegionUrlMaps) Get(ctx context.Context, key *meta.Key, options .
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEBetaRegionUrlMaps.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -49736,6 +50421,7 @@ func (g *GCEBetaRegionUrlMaps) Get(ctx context.Context, key *meta.Key, options .
 func (g *GCEBetaRegionUrlMaps) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computebeta.UrlMap, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEBetaRegionUrlMaps.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "RegionUrlMaps")
 
 	ck := &CallContextKey{
@@ -49743,6 +50429,7 @@ func (g *GCEBetaRegionUrlMaps) List(ctx context.Context, region string, fl *filt
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -49801,6 +50488,7 @@ func (g *GCEBetaRegionUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *c
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionUrlMaps.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -49842,6 +50530,7 @@ func (g *GCEBetaRegionUrlMaps) Delete(ctx context.Context, key *meta.Key, option
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionUrlMaps.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -49883,6 +50572,7 @@ func (g *GCEBetaRegionUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *
 		Operation: "Update",
 		Version:   meta.Version("beta"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCEBetaRegionUrlMaps.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -50135,6 +50825,7 @@ func (g *GCERegionUrlMaps) Get(ctx context.Context, key *meta.Key, options ...Op
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCERegionUrlMaps.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -50158,6 +50849,7 @@ func (g *GCERegionUrlMaps) Get(ctx context.Context, key *meta.Key, options ...Op
 func (g *GCERegionUrlMaps) List(ctx context.Context, region string, fl *filter.F, options ...Option) ([]*computega.UrlMap, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCERegionUrlMaps.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "RegionUrlMaps")
 
 	ck := &CallContextKey{
@@ -50165,6 +50857,7 @@ func (g *GCERegionUrlMaps) List(ctx context.Context, region string, fl *filter.F
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -50223,6 +50916,7 @@ func (g *GCERegionUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *compu
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionUrlMaps.Insert(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -50264,6 +50958,7 @@ func (g *GCERegionUrlMaps) Delete(ctx context.Context, key *meta.Key, options ..
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionUrlMaps.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -50305,6 +51000,7 @@ func (g *GCERegionUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *comp
 		Operation: "Update",
 		Version:   meta.Version("ga"),
 		Service:   "RegionUrlMaps",
+		Resource:  key,
 	}
 	klog.V(5).Infof("GCERegionUrlMaps.Update(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -50465,6 +51161,7 @@ func (g *GCEZones) Get(ctx context.Context, key *meta.Key, options ...Option) (*
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Zones",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("GCEZones.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -50488,6 +51185,7 @@ func (g *GCEZones) Get(ctx context.Context, key *meta.Key, options ...Option) (*
 func (g *GCEZones) List(ctx context.Context, fl *filter.F, options ...Option) ([]*computega.Zone, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("GCEZones.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Zones")
 
 	ck := &CallContextKey{
@@ -50495,6 +51193,7 @@ func (g *GCEZones) List(ctx context.Context, fl *filter.F, options ...Option) ([
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Zones",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -50759,6 +51458,7 @@ func (g *TDTcpRoutes) Get(ctx context.Context, key *meta.Key, options ...Option)
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("TDTcpRoutes.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -50783,6 +51483,7 @@ func (g *TDTcpRoutes) Get(ctx context.Context, key *meta.Key, options ...Option)
 func (g *TDTcpRoutes) List(ctx context.Context, fl *filter.F, options ...Option) ([]*networkservicesga.TcpRoute, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("TDTcpRoutes.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "TcpRoutes")
 
 	ck := &CallContextKey{
@@ -50790,6 +51491,7 @@ func (g *TDTcpRoutes) List(ctx context.Context, fl *filter.F, options ...Option)
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -50845,6 +51547,7 @@ func (g *TDTcpRoutes) Insert(ctx context.Context, key *meta.Key, obj *networkser
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDTcpRoutes.Create(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -50888,6 +51591,7 @@ func (g *TDTcpRoutes) Delete(ctx context.Context, key *meta.Key, options ...Opti
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDTcpRoutes.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -50930,6 +51634,7 @@ func (g *TDTcpRoutes) Patch(ctx context.Context, key *meta.Key, arg0 *networkser
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDTcpRoutes.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -51180,6 +51885,7 @@ func (g *TDBetaTcpRoutes) Get(ctx context.Context, key *meta.Key, options ...Opt
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("TDBetaTcpRoutes.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -51204,6 +51910,7 @@ func (g *TDBetaTcpRoutes) Get(ctx context.Context, key *meta.Key, options ...Opt
 func (g *TDBetaTcpRoutes) List(ctx context.Context, fl *filter.F, options ...Option) ([]*networkservicesbeta.TcpRoute, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("TDBetaTcpRoutes.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "TcpRoutes")
 
 	ck := &CallContextKey{
@@ -51211,6 +51918,7 @@ func (g *TDBetaTcpRoutes) List(ctx context.Context, fl *filter.F, options ...Opt
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -51266,6 +51974,7 @@ func (g *TDBetaTcpRoutes) Insert(ctx context.Context, key *meta.Key, obj *networ
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDBetaTcpRoutes.Create(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -51309,6 +52018,7 @@ func (g *TDBetaTcpRoutes) Delete(ctx context.Context, key *meta.Key, options ...
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDBetaTcpRoutes.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -51351,6 +52061,7 @@ func (g *TDBetaTcpRoutes) Patch(ctx context.Context, key *meta.Key, arg0 *networ
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "TcpRoutes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDBetaTcpRoutes.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -51601,6 +52312,7 @@ func (g *TDMeshes) Get(ctx context.Context, key *meta.Key, options ...Option) (*
 		Operation: "Get",
 		Version:   meta.Version("ga"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("TDMeshes.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -51625,6 +52337,7 @@ func (g *TDMeshes) Get(ctx context.Context, key *meta.Key, options ...Option) (*
 func (g *TDMeshes) List(ctx context.Context, fl *filter.F, options ...Option) ([]*networkservicesga.Mesh, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("TDMeshes.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "ga", "Meshes")
 
 	ck := &CallContextKey{
@@ -51632,6 +52345,7 @@ func (g *TDMeshes) List(ctx context.Context, fl *filter.F, options ...Option) ([
 		Operation: "List",
 		Version:   meta.Version("ga"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -51687,6 +52401,7 @@ func (g *TDMeshes) Insert(ctx context.Context, key *meta.Key, obj *networkservic
 		Operation: "Insert",
 		Version:   meta.Version("ga"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDMeshes.Create(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -51730,6 +52445,7 @@ func (g *TDMeshes) Delete(ctx context.Context, key *meta.Key, options ...Option)
 		Operation: "Delete",
 		Version:   meta.Version("ga"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDMeshes.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -51772,6 +52488,7 @@ func (g *TDMeshes) Patch(ctx context.Context, key *meta.Key, arg0 *networkservic
 		Operation: "Patch",
 		Version:   meta.Version("ga"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDMeshes.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -52022,6 +52739,7 @@ func (g *TDBetaMeshes) Get(ctx context.Context, key *meta.Key, options ...Option
 		Operation: "Get",
 		Version:   meta.Version("beta"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 
 	klog.V(5).Infof("TDBetaMeshes.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -52046,6 +52764,7 @@ func (g *TDBetaMeshes) Get(ctx context.Context, key *meta.Key, options ...Option
 func (g *TDBetaMeshes) List(ctx context.Context, fl *filter.F, options ...Option) ([]*networkservicesbeta.Mesh, error) {
 	opts := mergeOptions(options)
 	klog.V(5).Infof("TDBetaMeshes.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 	projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "beta", "Meshes")
 
 	ck := &CallContextKey{
@@ -52053,6 +52772,7 @@ func (g *TDBetaMeshes) List(ctx context.Context, fl *filter.F, options ...Option
 		Operation: "List",
 		Version:   meta.Version("beta"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -52108,6 +52828,7 @@ func (g *TDBetaMeshes) Insert(ctx context.Context, key *meta.Key, obj *networkse
 		Operation: "Insert",
 		Version:   meta.Version("beta"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDBetaMeshes.Create(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -52151,6 +52872,7 @@ func (g *TDBetaMeshes) Delete(ctx context.Context, key *meta.Key, options ...Opt
 		Operation: "Delete",
 		Version:   meta.Version("beta"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDBetaMeshes.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -52193,6 +52915,7 @@ func (g *TDBetaMeshes) Patch(ctx context.Context, key *meta.Key, arg0 *networkse
 		Operation: "Patch",
 		Version:   meta.Version("beta"),
 		Service:   "Meshes",
+		Resource:  key,
 	}
 	klog.V(5).Infof("TDBetaMeshes.Patch(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)

--- a/pkg/cloud/gen/main.go
+++ b/pkg/cloud/gen/main.go
@@ -771,6 +771,7 @@ func (g *{{.GCPWrapType}}) Get(ctx context.Context, key *meta.Key, options... Op
 		Operation: "Get",
 		Version: meta.Version("{{.Version}}"),
 		Service: "{{.Service}}",
+		Resource: key,
 	}
 
 	klog.V(5).Infof("{{.GCPWrapType}}.Get(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -810,16 +811,19 @@ func (g *{{.GCPWrapType}}) Get(ctx context.Context, key *meta.Key, options... Op
 func (g *{{.GCPWrapType}}) List(ctx context.Context, fl *filter.F, options... Option) ([]*{{.FQObjectType}}, error) {
         opts := mergeOptions(options)
 	klog.V(5).Infof("{{.GCPWrapType}}.List(%v, %v, %v) called", ctx, fl, opts)
+	key := &meta.Key{}
 {{- end -}}
 {{- if .KeyIsRegional}}
 func (g *{{.GCPWrapType}}) List(ctx context.Context, region string, fl *filter.F, options... Option) ([]*{{.FQObjectType}}, error) {
         opts := mergeOptions(options)
 	klog.V(5).Infof("{{.GCPWrapType}}.List(%v, %v, %v, %v) called", ctx, region, fl, opts)
+	key := &meta.Key{Region: region}
 {{- end -}}
 {{- if .KeyIsZonal}}
 func (g *{{.GCPWrapType}}) List(ctx context.Context, zone string, fl *filter.F, options... Option) ([]*{{.FQObjectType}}, error) {
         opts := mergeOptions(options)
 	klog.V(5).Infof("{{.GCPWrapType}}.List(%v, %v, %v, %v) called", ctx, zone, fl, opts)
+	key := &meta.Key{Name: zone}
 {{- end}}
         projectID := getProjectID(ctx, g.s.ProjectRouter, opts, "{{.Version}}", "{{.Service}}")
 
@@ -828,6 +832,7 @@ func (g *{{.GCPWrapType}}) List(ctx context.Context, zone string, fl *filter.F, 
 		Operation: "List",
 		Version: meta.Version("{{.Version}}"),
 		Service: "{{.Service}}",
+		Resource: key,
 	}
 
 	callObserverStart(ctx, ck)
@@ -901,6 +906,7 @@ func (g *{{.GCPWrapType}}) Insert(ctx context.Context, key *meta.Key, obj *{{.FQ
 		Operation: "Insert",
 		Version: meta.Version("{{.Version}}"),
 		Service: "{{.Service}}",
+		Resource: key,
 	}
 	{{- if .IsNetworkServices}}
 	klog.V(5).Infof("{{.GCPWrapType}}.Create(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
@@ -965,6 +971,7 @@ func (g *{{.GCPWrapType}}) Delete(ctx context.Context, key *meta.Key, options...
 		Operation: "Delete",
 		Version: meta.Version("{{.Version}}"),
 		Service: "{{.Service}}",
+		Resource: key,
 	}
 	klog.V(5).Infof("{{.GCPWrapType}}.Delete(%v, %v): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)
@@ -1017,6 +1024,7 @@ func (g *{{.GCPWrapType}}) AggregatedList(ctx context.Context, fl *filter.F, opt
 		Operation: "AggregatedList",
 		Version: meta.Version("{{.Version}}"),
 		Service: "{{.Service}}",
+		Resource: &meta.Key{},
 	}
 
 	klog.V(5).Infof("{{.GCPWrapType}}.AggregatedList(%v, %v): projectID = %v, ck = %+v", ctx, fl, projectID, ck)
@@ -1074,6 +1082,7 @@ func (g *{{.GCPWrapType}}) ListUsable(ctx context.Context, fl *filter.F, options
 		Operation: "ListUsable",
 		Version: meta.Version("{{.Version}}"),
 		Service: "{{.Service}}",
+		Resource: &meta.Key{},
 	}
         callObserverStart(ctx, ck)
 	if err := g.s.RateLimiter.Accept(ctx, ck); err != nil {
@@ -1138,6 +1147,7 @@ func (g *{{.GCPWrapType}}) {{.FcnArgs}} {
 		Operation: "{{.Name}}",
 		Version: meta.Version("{{.Version}}"),
 		Service: "{{.Service}}",
+		Resource: key,
 	}
 	klog.V(5).Infof("{{.GCPWrapType}}.{{.Name}}(%v, %v, ...): projectID = %v, ck = %+v", ctx, key, projectID, ck)
 	callObserverStart(ctx, ck)


### PR DESCRIPTION
This allows the observer to know the location for the given operation.